### PR TITLE
[CHORE] 방장, 참여자 둘 다 설정버튼으로 수정

### DIFF
--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -89,26 +89,11 @@ class DetailWaitViewController: BaseViewController {
 
     private lazy var settingButton: UIButton = {
         let button = SettingButton()
-        button.menu = UIMenu(options: [], children: [
-                UIAction(title: "방 정보 수정", handler: { _ in
-                    self.presentModal()
-                }),
-                UIAction(title: "방 삭제", handler: { _ in
-                    self.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)
-                })])
+        button.menu = setExitButtonMenu()
         button.showsMenuAsPrimaryAction = true
         return button
     }()
-    private lazy var exitButton: UIButton = {
-        let button = ExitButton()
-        let buttonAction = UIAction { _ in
-            self.makeRequestAlert(title: AlertText.exit.title, message: AlertText.exit.message, okTitle: AlertText.exit.okTitle, okAction: nil)
-        }
-        button.addAction(buttonAction, for: .touchUpInside)
-        return button
-    }()
     private let titleView = DetailWaitTitleView()
-
     private let togetherFriendText: UILabel = {
         let label = UILabel()
         label.text = "함께하는 친구들"
@@ -209,7 +194,7 @@ class DetailWaitViewController: BaseViewController {
 
     override func configUI() {
         view.backgroundColor = .darkGrey002
-        setupNavigationRightButton()
+        setupSettingButton()
     }
 
     // MARK: - func
@@ -263,21 +248,26 @@ class DetailWaitViewController: BaseViewController {
         navigationItem.rightBarButtonItem = settingButton
     }
 
-    private func setupExitButton() {
-        let rightOffsetSettingButton = super.removeBarButtonItemOffset(with: exitButton, offsetX: -10)
-        let exitButton = super.makeBarButtonItem(with: rightOffsetSettingButton)
-
-        navigationItem.rightBarButtonItem = exitButton
-    }
-
-    private func setupNavigationRightButton() {
+    private func setExitButtonMenu() -> UIMenu {
         if isOwner {
-            setupSettingButton()
+            let menu = UIMenu(options: [], children: [
+                    UIAction(title: "방 정보 수정", handler: { _ in
+                        self.presentModal()
+                    }),
+                    UIAction(title: "방 삭제", handler: { _ in
+                        self.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)
+                    })])
+            return menu
         } else {
-            setupExitButton()
+            let menu = UIMenu(options: [], children: [
+                    UIAction(title: "방 나가기", handler: { _ in
+                        self.makeRequestAlert(title: UserStatus.member.alertText.title, message: UserStatus.member.alertText.message, okTitle: UserStatus.member.alertText.okTitle, okAction: nil)
+                    })
+                ])
+            return menu
         }
     }
-    
+
     private func touchUpToShowToast() {
         UIPasteboard.general.string = "초대코드"
         self.showToast(message: "코드 복사 완료!")


### PR DESCRIPTION
## 🟣 관련 이슈
- close #32 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 방장과 참여자 둘 다 톱니바퀴 설정버튼으로 수정했습니다.
- 추후에 참여한 사람의 캐릭터를 바꿀 수 있게 설정버튼에 추가할 예정입니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- 나가기 모양의 버튼이었을때 바로 나가기 Alert창이 떠서 나가는 것에 대한 위험이 있었는데 중간에 menu를 넣음으로써 depth가 깊어졌습니다.
## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 251번째 줄 부터 275번째 줄에 if안에 let 설정해서 return하는 방식 괜찮나요 ??
## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
![Jun-14-2022 11-20-40](https://user-images.githubusercontent.com/78677571/173479754-fac94fce-7dba-4ad1-bd90-4bbf66c023ea.gif)

