### PR TITLE
[FEAT] 캘린더 기간 설정 기능 추가

### DIFF
--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/DetailHalfModalController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/DetailHalfModalController.swift
@@ -11,9 +11,9 @@ import FSCalendar
 import SnapKit
 
 class DetailModalController: BaseViewController {
-    var isFirstTap = false
-    var selectStartDate = Date()
-    var memberCount = 7
+    private var isFirstTap = false
+    private var selectStartDate = Date()
+    private var memberCount = 7
 
     // MARK: - property
 
@@ -58,6 +58,24 @@ class DetailModalController: BaseViewController {
         label.textColor = .white
         return label
     }()
+    private lazy var preButton: UIButton = {
+        let button = UIButton()
+        let action = UIAction { _ in
+            self.changeMonth(next: false)
+        }
+        button.setTitle("<", for: .normal)
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
+    private lazy var nextButton: UIButton = {
+        let button = UIButton()
+        let action = UIAction { _ in
+            self.changeMonth(next: true)
+        }
+        button.setTitle(">", for: .normal)
+        button.addAction(action, for: .touchUpInside)
+        return button
+    }()
     private var calendar: FSCalendar = {
         let calendar = FSCalendar()
         calendar.locale = Locale(identifier: "ko_KR")
@@ -65,7 +83,6 @@ class DetailModalController: BaseViewController {
         calendar.makeBorderLayer(color: .grey002)
         calendar.appearance.headerDateFormat = "YYYY년 MM월"
         calendar.appearance.headerTitleColor = .white
-//        calendar.scrollDirection = .vertical
         calendar.appearance.headerTitleAlignment = .center
         calendar.appearance.headerMinimumDissolvedAlpha = 0.0
         calendar.appearance.weekdayTextColor = .grey005
@@ -179,6 +196,18 @@ class DetailModalController: BaseViewController {
             $0.width.equalTo(360)
         }
 
+        view.addSubview(preButton)
+        preButton.snp.makeConstraints {
+            $0.top.equalTo(startSettingLabel.snp.bottom).offset(38)
+            $0.leading.equalToSuperview().inset(100)
+        }
+
+        view.addSubview(nextButton)
+        nextButton.snp.makeConstraints {
+            $0.top.equalTo(startSettingLabel.snp.bottom).offset(38)
+            $0.trailing.equalToSuperview().inset(100)
+        }
+
         view.addSubview(tipLabel)
         tipLabel.snp.makeConstraints {
             $0.top.equalTo(calendar.snp.bottom).offset(8)
@@ -225,6 +254,15 @@ class DetailModalController: BaseViewController {
     private func setupDelegation() {
         calendar.delegate = self
         calendar.dataSource = self
+    }
+
+    private func changeMonth(next: Bool) {
+        let todayCalendar = Calendar.current
+        var currentPage = calendar.currentPage
+        var dateComponents = DateComponents()
+        dateComponents.month = next ? 1 : -1
+        currentPage = todayCalendar.date(byAdding: dateComponents, to: currentPage)!
+        calendar.setCurrentPage(currentPage, animated: true)
     }
 
     // MARK: - selector

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/DetailHalfModalController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/DetailHalfModalController.swift
@@ -404,8 +404,7 @@ extension DetailModalController: FSCalendarDelegate {
 extension DetailModalController: FSCalendarDataSource { }
 
 extension DetailModalController: FSCalendarDelegateAppearance {
-//    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
-//        calendar.appearance.titleTodayColor = .green
-//        return .mainRed
-//    }
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
+        return .darkRed
+    }
 }


### PR DESCRIPTION
## 🟣 관련 이슈
- close #45 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 진행기간 설정에 오늘보다 이전 날짜는 선택 안되고 alert창을 띄웁니다
- 최대 7일까지 선택이 가능하게 구현했습니다
- 시작 날짜(첫 탭)를 선택하면 선택 가능한 부분은 흰색, 아닌 부분은 회색으로 사용자가 보기에 직관적으로 구현했습니다
- 시작과 끝 기간을 설정하면, 과거를 제외한 모든 일이 흰색으로 보여서 터치가 가능하도록 구현했습니다
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 301~313번째 줄 클로저를 이용한 더 짧은 코드로 변경이 가능한가요 ?? 가능한지 알려만 주세요 이제 막 클로저랑 친해지려 노력중이예요
- 제일 처음 들어왔을땐 과거를 제외한 모든 날짜에 터치 가능하게 표시해야해서 isFirstTap 함수로 처음인지 아닌지를 구분했는데, 두 시간을 비교하는 과정이 순탄치 않아서 boolean값으로 컨트롤 했어요 더 좋은 방법이 있을 것 같은데 아시면 알려주세요 !
## 🟣 참고 사항
- 시작과 끝기간을 설정하고 수정하려고 다시 탭하면 반짝하는 이펙트가 있는데 수정이 어렵네요 ..ㅠ
- 예를들어 시작일이 6월 15일이면 6월 22일 이후로는 설정이 안되는데 7월이 넘어가면 alert는 뜨지만 선택이 되요.. 이거도 수정이 쉽지않네요 ..

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
![Jun-15-2022 16-29-26](https://user-images.githubusercontent.com/78677571/173768918-3ed3b4d2-32e0-47b5-9be9-bb78233ba6a7.gif)

