### PR TITLE
[FEAT] DetailEditView 모달 내릴때 alert 표시

### DIFF
--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -219,18 +219,11 @@ class DetailEditViewController: BaseViewController {
     // MARK: - func
 
     private func presentationControllerDidAttemptToDismissAlert() {
-        let hasStardDate = calendarView.tempStartDateText.isEmpty
-        let hasEndDate = calendarView.tempEndDateText.isEmpty
-        let hasDateRange = !hasStardDate && !hasEndDate
-        
         guard calendarView.isFirstTap else {
-            showSaveAlert()
+            dismiss(animated: true)
             return
         }
-        if hasDateRange {
-            showSaveAlert()
-            return
-        }
+        
         showDiscardChangAlert()
     }
 
@@ -241,15 +234,6 @@ class DetailEditViewController: BaseViewController {
             self?.dismiss(animated: true)
         }, nil]
         makeActionSheet(actionTitles: actionTitles, actionStyle: actionStyle, actions: actions)
-    }
-
-    private func showSaveAlert() {
-        makeRequestAlert(title: "변경사항을 저장합니다", message: "변경사항을 저장하시겠습니까??", okAction: { [weak self] _ in
-            guard let startDate = self?.calendarView.tempStartDateText else { return }
-            guard let endDate = self?.calendarView.tempEndDateText else { return }
-            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startDate, "endDate": endDate])
-            self?.dismiss(animated: true)
-        })
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -244,6 +244,9 @@ class DetailEditViewController: BaseViewController {
 
     private func showSaveAlert() {
         makeRequestAlert(title: "변경사항을 저장합니다", message: "변경사항을 저장하시겠습니까??", okAction: { [weak self] _ in
+            guard let startDate = self?.calendarView.tempStartDateText else { return }
+            guard let endDate = self?.calendarView.tempEndDateText else { return }
+            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startDate, "endDate": endDate])
             self?.dismiss(animated: true)
         })
     }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -122,6 +122,8 @@ class DetailEditViewController: BaseViewController {
     override func configUI() {
         super.configUI()
         self.navigationController?.isNavigationBarHidden = true
+        self.presentationController?.delegate = self
+        isModalInPresentation = true
     }
 
     override func render() {
@@ -212,5 +214,43 @@ class DetailEditViewController: BaseViewController {
         memberCountLabel.text = String(Int(sender.value)) + "인"
         memberCountLabel.font = .font(.regular, ofSize: 24)
         memberCountLabel.textColor = .white
+    }
+
+    // MARK: - func
+
+    private func presentationControllerDidAttemptToDismissAlert() {
+        let hasStardDate = calendarView.tempStartDateText.isEmpty
+        let hasEndDate = calendarView.tempEndDateText.isEmpty
+        print(calendarView.tempStartDateText)
+        print(calendarView.tempEndDateText)
+        guard calendarView.isEdited else {
+            showSaveAlert()
+            return
+        }
+        guard hasStardDate || hasEndDate else {
+            dismiss(animated: true)
+            return
+        }
+        showDiscardChangAlert()
+        
+    }
+
+    private func showDiscardChangAlert() {
+        makeRequestAlert(title: "변경사항을 폐기합니다", message: "변경사항은 저장되지 않고 폐기됩니다. \n 폐기하시겠습니까??", okAction: { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+    }
+    
+    private func showSaveAlert() {
+        makeRequestAlert(title: "변경사항을 저장합니다", message: "변경사항을 저장하시겠습니까??", okAction: { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+    }
+}
+
+
+extension DetailEditViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        presentationControllerDidAttemptToDismissAlert()
     }
 }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -237,9 +237,12 @@ class DetailEditViewController: BaseViewController {
     }
 
     private func showDiscardChangAlert() {
-        makeRequestAlert(title: "변경사항을 폐기합니다", message: "변경사항은 저장되지 않고 폐기됩니다. \n 폐기하시겠습니까??", okAction: { [weak self] _ in
+        let actionTitles = ["변경 사항 폐기", "취소"]
+        let actionStyle: [UIAlertAction.Style] = [.destructive, .cancel]
+        let actions: [((UIAlertAction) -> Void)?] = [{ [weak self] _ in
             self?.dismiss(animated: true)
-        })
+        }, nil]
+        makeActionSheet(actionTitles: actionTitles, actionStyle: actionStyle, actions: actions)
     }
 
     private func showSaveAlert() {

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -221,9 +221,11 @@ class DetailEditViewController: BaseViewController {
     private func presentationControllerDidAttemptToDismissAlert() {
         let hasStardDate = calendarView.tempStartDateText.isEmpty
         let hasEndDate = calendarView.tempEndDateText.isEmpty
-        print(calendarView.tempStartDateText)
-        print(calendarView.tempEndDateText)
         guard calendarView.isEdited else {
+            showSaveAlert()
+            return
+        }
+        if !hasStardDate && !hasEndDate {
             showSaveAlert()
             return
         }
@@ -232,7 +234,6 @@ class DetailEditViewController: BaseViewController {
             return
         }
         showDiscardChangAlert()
-        
     }
 
     private func showDiscardChangAlert() {
@@ -240,7 +241,7 @@ class DetailEditViewController: BaseViewController {
             self?.dismiss(animated: true)
         })
     }
-    
+
     private func showSaveAlert() {
         makeRequestAlert(title: "변경사항을 저장합니다", message: "변경사항을 저장하시겠습니까??", okAction: { [weak self] _ in
             self?.dismiss(animated: true)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -221,16 +221,14 @@ class DetailEditViewController: BaseViewController {
     private func presentationControllerDidAttemptToDismissAlert() {
         let hasStardDate = calendarView.tempStartDateText.isEmpty
         let hasEndDate = calendarView.tempEndDateText.isEmpty
-        guard calendarView.isEdited else {
+        let hasDateRange = !hasStardDate && !hasEndDate
+        
+        guard calendarView.isFirstTap else {
             showSaveAlert()
             return
         }
-        if !hasStardDate && !hasEndDate {
+        if hasDateRange {
             showSaveAlert()
-            return
-        }
-        guard hasStardDate || hasEndDate else {
-            dismiss(animated: true)
             return
         }
         showDiscardChangAlert()

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -192,6 +192,7 @@ extension CalendarView: FSCalendarDelegate {
     }
 
     func calendar(_ calendar: FSCalendar, didDeselect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        tempEndDateText = ""
         isEdited = true
         (calendar.selectedDates).forEach {
             calendar.deselect($0)

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -18,7 +18,7 @@ class CalendarView: UIView {
     var endDateText = ""
     var tempStartDateText = ""
     var tempEndDateText = ""
-    var isEdited = false
+    var isFirstTap = false
     
     private enum CalendarMoveType {
         case previous
@@ -167,7 +167,7 @@ class CalendarView: UIView {
 
 extension CalendarView: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        isEdited = true
+        isFirstTap = true
         let isSelectedDateRange = calendar.selectedDates.count == 2
         let isReclickedStartDate = calendar.selectedDates.count > 2
         if isSelectedDateRange {
@@ -193,7 +193,7 @@ extension CalendarView: FSCalendarDelegate {
 
     func calendar(_ calendar: FSCalendar, didDeselect date: Date, at monthPosition: FSCalendarMonthPosition) {
         tempEndDateText = ""
-        isEdited = true
+        isFirstTap = true
         (calendar.selectedDates).forEach {
             calendar.deselect($0)
         }

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -18,6 +18,7 @@ class CalendarView: UIView {
     var endDateText = ""
     var tempStartDateText = ""
     var tempEndDateText = ""
+    var isEdited = false
     
     private enum CalendarMoveType {
         case previous
@@ -166,21 +167,21 @@ class CalendarView: UIView {
 
 extension CalendarView: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        let isClickedStartDate = calendar.selectedDates.count == 1
+        isEdited = true
         let isSelectedDateRange = calendar.selectedDates.count == 2
         let isReclickedStartDate = calendar.selectedDates.count > 2
-        if isClickedStartDate {
-            selectStartDate = date
-            calendar.reloadData()
-        } else if isSelectedDateRange {
+        if isSelectedDateRange {
+            tempEndDateText = date.dateToString
             if countDateRange() > 7 {
                 calendar.deselect(date)
-                viewController?.makeAlert(title: "인원 수 제한", message: "최대 7일까지 선택가능해요 !")
+                viewController?.makeAlert(title: "설정 기간 제한", message: "최대 7일까지 선택가능해요 !")
             } else {
                 setDateRange()
                 calendar.reloadData()
             }
         } else if isReclickedStartDate {
+            tempStartDateText = date.dateToString
+            tempEndDateText = ""
             (calendar.selectedDates).forEach {
                 calendar.deselect($0)
             }
@@ -191,6 +192,7 @@ extension CalendarView: FSCalendarDelegate {
     }
 
     func calendar(_ calendar: FSCalendar, didDeselect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        isEdited = true
         (calendar.selectedDates).forEach {
             calendar.deselect($0)
         }


### PR DESCRIPTION
## 🟣 관련 이슈
- close #115 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 모달을 내릴 때 alert 표시했습니다.
- 제일 처음 수정하러 들어갔을 땐 기본으로 오늘로부터 5일 후 까지인데 그 상태에서 모달을 내렸을땐 "저장하시겠습니까??" 가 뜨고
- 시작일만 정하고 모달을 내렸을 땐 "폐기하시겠습니까??" 가 뜨고
- 시작과 끝날짜를 다 정하고도 모달을 내리면 "저장하시겠습니까??" 가 뜹니다.

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- 해당 alert멘트가 괜찮은지 검토 부탁드립니다.
- `presentationControllerDidAttemptToDismissAlert` 이 함수 내부에서 guard와 if를 섞어서 사용하는데 괜찮은 방법인지 조언부탁드립니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항
![Aug-09-2022 21-12-12](https://user-images.githubusercontent.com/78677571/183644276-41e035c1-a482-4274-892d-c8f4fc928df0.gif)
