### PR TITLE
[CHORE] 마니또 시작 후 대기방으로 돌아가는 flow 수정

### DIFF
--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -32,7 +32,7 @@ final class SelectManittoViewController: BaseViewController {
             self.dismiss(animated: true, completion: {
                 let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
                 guard let viewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
-                parentViewController.popViewController(animated: false)
+                parentViewController.popViewController(animated: true)
                 parentViewController.pushViewController(viewController, animated: true)
             })
         }

--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -32,6 +32,7 @@ final class SelectManittoViewController: BaseViewController {
             self.dismiss(animated: true, completion: {
                 let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
                 guard let viewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
+                parentViewController.popViewController(animated: false)
                 parentViewController.pushViewController(viewController, animated: true)
             })
         }

--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -29,12 +29,11 @@ final class SelectManittoViewController: BaseViewController {
     private lazy var okAction: UIAction = {
         let action = UIAction { _ in
             guard let parentViewController = self.presentingViewController as? UINavigationController else { return }
-            self.dismiss(animated: true, completion: {
-                let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
-                guard let viewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
-                parentViewController.popViewController(animated: true)
-                parentViewController.pushViewController(viewController, animated: true)
-            })
+            self.dismiss(animated: true)
+            let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
+            guard let viewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
+            parentViewController.popViewController(animated: false)
+            parentViewController.pushViewController(viewController, animated: true)
         }
         return action
     }()

--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -28,12 +28,12 @@ final class SelectManittoViewController: BaseViewController {
 
     private lazy var okAction: UIAction = {
         let action = UIAction { _ in
-            guard let parentViewController = self.presentingViewController as? UINavigationController else { return }
-            self.dismiss(animated: true)
+            guard let navigationController = self.presentingViewController as? UINavigationController else { return }
             let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
             guard let viewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
-            parentViewController.popViewController(animated: false)
-            parentViewController.pushViewController(viewController, animated: true)
+            navigationController.popViewController(animated: true)
+            navigationController.pushViewController(viewController, animated: false)
+            self.dismiss(animated: true)
         }
         return action
     }()


### PR DESCRIPTION
## 🟣 관련 이슈
- close #124 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 마니또 시작 버튼 눌러서 시작 후 진행 화면이 떳을 때 뒤로가면 다시 대기중 화면으로 돌아가던 flow를 수정했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- 넘어가는 화면이 적절한가요 ?? 살짝 끊기는 것 처럼 보일수도 있을 것 같아서요 !
- GIF참고해주세요 !
- 1번 2번 어떤게 더 나은지 답변 부탁드립니다. 화면 전환 애니메이션 차이입니다 !
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
- 1번
![Aug-11-2022 15-05-27](https://user-images.githubusercontent.com/78677571/184073411-63599ebf-c4ee-4193-ad15-1c4afc9f1f17.gif)

- 2전
![Aug-11-2022 19-49-33](https://user-images.githubusercontent.com/78677571/184136424-7812c85a-cb93-44d9-8655-c4952652999c.gif)


