### PR TITLE
[FEAT] 마니띠 누르면 애니메이션 동작 추가

### DIFF
--- a/Manito/Manito/Global/Resource/Storyboards/DetailIng.storyboard
+++ b/Manito/Manito/Global/Resource/Storyboards/DetailIng.storyboard
@@ -56,7 +56,7 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="1000원 이하의 선물 주고 인증샷 받기" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vma-X3-7Uq">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000원 이하의 선물 주고 인증샷 받기" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vma-X3-7Uq">
                                         <rect key="frame" x="24" y="41" width="311" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="AzM-fe-C6S"/>
@@ -73,7 +73,7 @@
                                     <constraint firstItem="kHA-mR-fkA" firstAttribute="top" secondItem="ne3-xF-fpF" secondAttribute="top" constant="16" id="ZVo-eI-tCX"/>
                                     <constraint firstAttribute="trailing" secondItem="kHA-mR-fkA" secondAttribute="trailing" constant="120" id="duX-hl-aGi"/>
                                     <constraint firstAttribute="trailing" secondItem="vma-X3-7Uq" secondAttribute="trailing" constant="23" id="hNc-ui-g86"/>
-                                    <constraint firstAttribute="bottom" secondItem="vma-X3-7Uq" secondAttribute="bottom" constant="16" id="ncN-Es-3Bv"/>
+                                    <constraint firstAttribute="bottom" secondItem="vma-X3-7Uq" secondAttribute="bottom" constant="19" id="ncN-Es-3Bv"/>
                                     <constraint firstAttribute="height" constant="100" id="yle-T4-6Dg"/>
                                 </constraints>
                             </view>

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -33,8 +33,7 @@ class DetailIngViewController: BaseViewController {
     @IBOutlet weak var manitoMemoryButton: UIButton!
 
     private lazy var manitiRealIconView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = ImageLiterals.imgMa
+        let imageView = UIImageView(image: ImageLiterals.imgMa)
         imageView.alpha = 0
         return imageView
     }()
@@ -154,7 +153,6 @@ class DetailIngViewController: BaseViewController {
     
     @objc
     private func didTapManito() {
-        print("tap")
         UIView.animate(withDuration: 1.0) {
             self.manitiIconView.alpha = 0
             self.manitiRealIconView.alpha = 1

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -32,6 +32,13 @@ class DetailIngViewController: BaseViewController {
     @IBOutlet weak var letterBoxButton: UIButton!
     @IBOutlet weak var manitoMemoryButton: UIButton!
 
+    private lazy var manitiRealIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = ImageLiterals.imgMa
+        imageView.alpha = 0
+        return imageView
+    }()
+    
     private let manitoOpenButton: UIButton = {
         let button = MainButton()
         button.title = "마니또 공개"
@@ -47,6 +54,14 @@ class DetailIngViewController: BaseViewController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(7)
             $0.centerX.equalToSuperview()
         }
+        
+        view.addSubview(manitiRealIconView)
+        manitiRealIconView.snp.makeConstraints {
+            $0.top.equalTo(manitiIconView.snp.top)
+            $0.trailing.equalTo(manitiIconView.snp.trailing)
+            $0.leading.equalTo(manitiIconView.snp.leading)
+            $0.bottom.equalTo(manitiIconView.snp.bottom)
+        }
     }
 
     override func configUI() {
@@ -56,6 +71,7 @@ class DetailIngViewController: BaseViewController {
         addActionMemoryViewController()
         addActionPushLetterViewController()
         addGestureMemberList()
+        addGestureManito()
         addActionOpenManittoViewController()
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.navigationItem.largeTitleDisplayMode = .never
@@ -94,6 +110,11 @@ class DetailIngViewController: BaseViewController {
         manitoMemoryButton.makeBorderLayer(color: .white)
     }
     
+    private func addGestureManito() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapManito))
+        manitiBackView.addGestureRecognizer(tapGesture)
+    }
+    
     private func addGestureMemberList() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(pushFriendListViewController(_:)))
         listBackView.addGestureRecognizer(tapGesture)
@@ -129,5 +150,20 @@ class DetailIngViewController: BaseViewController {
         let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
         let viewController = storyboard.instantiateViewController(withIdentifier: FriendListViewController.className)
         self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    @objc
+    private func didTapManito() {
+        print("tap")
+        UIView.animate(withDuration: 1.0) {
+            self.manitiIconView.alpha = 0
+            self.manitiRealIconView.alpha = 1
+        } completion: { _ in
+            UIView.animate(withDuration: 1.0, delay: 1.0) {
+                self.manitiIconView.alpha = 1
+                self.manitiRealIconView.alpha = 0
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
close #116 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
마니띠를 눌렀을때 2초동안 보이고 다시 사라지는 애니메이션을 추가했습니당.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 저는 마니띠를 manitoRealImageView 라고 줬는데 좀 더 제대로된 ... 좋은게 뭐가 있을까용..ㅎㅎ
- UIView의 애니메이션 클로저에서는 self를 약한 참조를 하지 않았는데 괜찮을까요? 
- 오토레이아웃이 하나 잘못 되어있어서 수정했습니다. 

## 🟣 참고 사항

https://user-images.githubusercontent.com/59243274/184150965-3442995a-2f35-41c8-9db5-d2f54bab95e3.mp4


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

