### PR TITLE
[FEAT] 날짜 변경에 따라 마니또 시작버튼 상태 변경

### DIFF
--- a/Manito/Manito/Global/Extension/Notification+Extension.swift
+++ b/Manito/Manito/Global/Extension/Notification+Extension.swift
@@ -14,4 +14,5 @@ extension Notification.Name {
     static let dateNotification = Notification.Name("DateNotification")
     static let checkNotification = Notification.Name("CheckNotification")
     static let dateRangeNotification = Notification.Name("DateRangeNotification")
+    static let changeStartButtonNotification = Notification.Name("ChangeStartButtonNotification")
 }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -58,6 +58,7 @@ class DetailEditViewController: BaseViewController {
             guard let startText = self?.calendarView.tempStartDateText else { return }
             guard let endText = self?.calendarView.tempEndDateText else { return }
             NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startText, "endDate": endText])
+            NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
             self?.dismiss(animated: true)
         }
         button.setTitle("변경", for: .normal)

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -295,7 +295,9 @@ class DetailWaitViewController: BaseViewController {
         if isOwner {
             let menu = UIMenu(options: [], children: [
                     UIAction(title: "방 정보 수정", handler: { [weak self] _ in
-                        self.presentModal(from: self.startDateText, to: self.endDateText)
+                        guard let startDate = self?.startDateText else { return }
+                        guard let endDate = self?.endDateText else { return }
+                        self?.presentModal(from: startDate, to: endDate)
                     }),
                     UIAction(title: "방 삭제", handler: { [weak self] _ in
                         self?.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -30,24 +30,6 @@ class DetailWaitViewController: BaseViewController {
         case owner = 0
         case member = 1
 
-//        var buttonTitle: String {
-//            switch self {
-//            case .owner:
-//                return "마니또 시작"
-//            case .member:
-//                return "시작을 기다리는 중..."
-//            }
-//        }
-
-//        var buttonDisabled: Bool {
-//            switch self {
-//            case .owner:
-//                return false
-//            case .member:
-//                return true
-//            }
-//        }
-
         var alertText: AlertText {
             switch self {
             case .owner:
@@ -330,9 +312,10 @@ class DetailWaitViewController: BaseViewController {
         let formatter = DateFormatter()
         formatter.dateFormat = "yy.MM.dd"
         guard let startDate = formatter.date(from: startDateText) else { return }
-        let isPast = startDate.distance(to: Date()) > 0
+        let isPast = startDate.distance(to: Date()) > 86400
         let isToday = startDate.distance(to: Date()) < 86400
-        if !isPast && !isToday {
+        let canStart = !isPast && isToday
+        if !canStart {
             if isOwner {
                 let action: ((UIAlertAction) -> ()) = { [weak self] _ in
                     let fiveDaysInterval: TimeInterval = 86400 * 4

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -30,23 +30,23 @@ class DetailWaitViewController: BaseViewController {
         case owner = 0
         case member = 1
 
-        var buttonTitle: String {
-            switch self {
-            case .owner:
-                return "마니또 시작"
-            case .member:
-                return "시작을 기다리는 중..."
-            }
-        }
+//        var buttonTitle: String {
+//            switch self {
+//            case .owner:
+//                return "마니또 시작"
+//            case .member:
+//                return "시작을 기다리는 중..."
+//            }
+//        }
 
-        var buttonDisabled: Bool {
-            switch self {
-            case .owner:
-                return false
-            case .member:
-                return true
-            }
-        }
+//        var buttonDisabled: Bool {
+//            switch self {
+//            case .owner:
+//                return false
+//            case .member:
+//                return true
+//            }
+//        }
 
         var alertText: AlertText {
             switch self {
@@ -167,6 +167,10 @@ class DetailWaitViewController: BaseViewController {
     }()
 
     // MARK: - life cycle
+
+    deinit {
+        print("deInit")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -290,17 +294,17 @@ class DetailWaitViewController: BaseViewController {
     private func setExitButtonMenu() -> UIMenu {
         if isOwner {
             let menu = UIMenu(options: [], children: [
-                    UIAction(title: "방 정보 수정", handler: { _ in
+                    UIAction(title: "방 정보 수정", handler: { [weak self] _ in
                         self.presentModal(from: self.startDateText, to: self.endDateText)
                     }),
-                    UIAction(title: "방 삭제", handler: { _ in
-                        self.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)
+                    UIAction(title: "방 삭제", handler: { [weak self] _ in
+                        self?.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)
                     })])
             return menu
         } else {
             let menu = UIMenu(options: [], children: [
-                    UIAction(title: "방 나가기", handler: { _ in
-                        self.makeRequestAlert(title: UserStatus.member.alertText.title, message: UserStatus.member.alertText.message, okTitle: UserStatus.member.alertText.okTitle, okAction: nil)
+                    UIAction(title: "방 나가기", handler: { [weak self] _ in
+                        self?.makeRequestAlert(title: UserStatus.member.alertText.title, message: UserStatus.member.alertText.message, okTitle: UserStatus.member.alertText.okTitle, okAction: nil)
                     })
                 ])
             return menu

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -309,9 +309,7 @@ class DetailWaitViewController: BaseViewController {
     }
 
     private func isPastStartDate() {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yy.MM.dd"
-        guard let startDate = formatter.date(from: startDateText) else { return }
+        guard let startDate = startDateText.stringToDate else { return }
         let isPast = startDate.distance(to: Date()) > 86400
         let isToday = startDate.distance(to: Date()) < 86400
         let canStart = !isPast && isToday
@@ -319,8 +317,8 @@ class DetailWaitViewController: BaseViewController {
             if isOwner {
                 let action: ((UIAlertAction) -> ()) = { [weak self] _ in
                     let fiveDaysInterval: TimeInterval = 86400 * 4
-                    let startDate = formatter.string(from: Date())
-                    let endDate = formatter.string(from: Date() + fiveDaysInterval)
+                    let startDate = Date().dateToString
+                    let endDate = (Date() + fiveDaysInterval).dateToString
                     self?.presentModal(from: startDate, to: endDate, isDateEdit: true)
                 }
                 makeAlert(title: "날짜를 재설정 해주세요", message: "마니또 시작일이 지났습니다. \n 진행기간을 재설정 해주세요", okAction: action)

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -323,6 +323,7 @@ class DetailWaitViewController: BaseViewController {
 
     private func setupNotificationCenter() {
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveDateRange(_:)), name: .dateRangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(changeStartButton), name: .changeStartButtonNotification, object: nil)
     }
 
     private func isPastStartDate() {
@@ -371,6 +372,10 @@ class DetailWaitViewController: BaseViewController {
     @objc
     private func presentDetailEditViewController() {
         self.presentModal(from: self.startDateText, to: self.endDateText, isDateEdit: false)
+    }
+    
+    @objc private func changeStartButton() {
+        setStartButton()
     }
 }
 


### PR DESCRIPTION
## 🟣 관련 이슈
- close #126 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 시작날짜 변경에 따라 마니또 시작버튼이 활성화됩니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- 날짜 변경버튼을 누르면 Notification으로 알림을 줘서 함수를 실행시키는데 다른 방법이 있을까요 ?? 클로저를 사용하고 싶었는데 가능한지 잘 모르겠더라구요 ! 혹시 가능할까요...??
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

https://user-images.githubusercontent.com/78677571/184316160-09e48113-e402-48a2-b98e-1b4e3e0d7b56.mp4



<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

