### PR TITLE
[FEAT] 시작날짜 지났을 때 방 정보 변경시 default 날짜 추가

### DIFF
--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -293,7 +293,17 @@ class DetailWaitViewController: BaseViewController {
                     UIAction(title: "방 정보 수정", handler: { [weak self] _ in
                         guard let startText = self?.startDateText else { return }
                         guard let endText = self?.endDateText else { return }
-                        self?.presentModal(from: startText, to: endText, isDateEdit: false)
+
+                        guard let startDate = startText.stringToDate else { return }
+
+                        if startDate.distance(to: Date()) > 86400 {
+                            let fiveDaysInterval: TimeInterval = 86400 * 4
+                            let defaultStartDate = Date().dateToString
+                            let defaultEndDate = (Date() + fiveDaysInterval).dateToString
+                            self?.presentModal(from: defaultStartDate, to: defaultEndDate, isDateEdit: false)
+                        } else {
+                            self?.presentModal(from: startText, to: endText, isDateEdit: false)
+                        }
                     }),
                     UIAction(title: "방 삭제", handler: { [weak self] _ in
                         self?.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -312,13 +312,21 @@ class DetailWaitViewController: BaseViewController {
         let isAlreadyPastDate = startDate.distance(to: Date()) > 86400
         
         if isAlreadyPastDate {
-            let fiveDaysInterval: TimeInterval = 86400 * 4
-            let defaultStartDate = Date().dateToString
-            let defaultEndDate = (Date() + fiveDaysInterval).dateToString
-            self.presentModal(from: defaultStartDate, to: defaultEndDate, isDateEdit: false)
+            editInfoFromDefaultDate()
         } else {
-            self.presentModal(from: self.startDateText, to: self.endDateText, isDateEdit: false)
+            editInfoFromCurrentDate()
         }
+    }
+    
+    private func editInfoFromDefaultDate() {
+        let fiveDaysInterval: TimeInterval = 86400 * 4
+        let defaultStartDate = Date().dateToString
+        let defaultEndDate = (Date() + fiveDaysInterval).dateToString
+        self.presentModal(from: defaultStartDate, to: defaultEndDate, isDateEdit: false)
+    }
+    
+    private func editInfoFromCurrentDate() {
+        self.presentModal(from: self.startDateText, to: self.endDateText, isDateEdit: false)
     }
 
     private func touchUpToShowToast() {

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -291,19 +291,7 @@ class DetailWaitViewController: BaseViewController {
         if isOwner {
             let menu = UIMenu(options: [], children: [
                     UIAction(title: "방 정보 수정", handler: { [weak self] _ in
-                        guard let startText = self?.startDateText else { return }
-                        guard let endText = self?.endDateText else { return }
-
-                        guard let startDate = startText.stringToDate else { return }
-
-                        if startDate.distance(to: Date()) > 86400 {
-                            let fiveDaysInterval: TimeInterval = 86400 * 4
-                            let defaultStartDate = Date().dateToString
-                            let defaultEndDate = (Date() + fiveDaysInterval).dateToString
-                            self?.presentModal(from: defaultStartDate, to: defaultEndDate, isDateEdit: false)
-                        } else {
-                            self?.presentModal(from: startText, to: endText, isDateEdit: false)
-                        }
+                        self?.presentEditRoomView()
                     }),
                     UIAction(title: "방 삭제", handler: { [weak self] _ in
                         self?.makeRequestAlert(title: UserStatus.owner.alertText.title, message: UserStatus.owner.alertText.message, okTitle: UserStatus.owner.alertText.okTitle, okAction: nil)
@@ -316,6 +304,20 @@ class DetailWaitViewController: BaseViewController {
                     })
                 ])
             return menu
+        }
+    }
+
+    private func presentEditRoomView() {
+        guard let startDate = startDateText.stringToDate else { return }
+        let isAlreadyPastDate = startDate.distance(to: Date()) > 86400
+        
+        if isAlreadyPastDate {
+            let fiveDaysInterval: TimeInterval = 86400 * 4
+            let defaultStartDate = Date().dateToString
+            let defaultEndDate = (Date() + fiveDaysInterval).dateToString
+            self.presentModal(from: defaultStartDate, to: defaultEndDate, isDateEdit: false)
+        } else {
+            self.presentModal(from: self.startDateText, to: self.endDateText, isDateEdit: false)
         }
     }
 


### PR DESCRIPTION
## 🟣 관련 이슈
- close #127 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 시작 날짜가 지났을 때 alert이 표시되고 모달이 올라왔을 때 날짜를 수정하지 않고 dismiss 후 방 정보 수정을 누르면 날짜가 기존 설정날짜로 되있어서 깨지는 현상이 발생하는 걸 해결했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- 방정보수정 UIAction 클로저에 다 때려박힌 느낌인데 괜찮을까요 ..??
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

https://user-images.githubusercontent.com/78677571/184321455-53c459f1-98e0-4ffb-8612-ef678abe82aa.mp4


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

