### PR TITLE
[CHOER] 레버 스와이프 영역 확장

### DIFF
--- a/Manito/Manito/Global/Resource/Storyboards/Interaction.storyboard
+++ b/Manito/Manito/Global/Resource/Storyboards/Interaction.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Chd-a1-oJY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21219" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Chd-a1-oJY">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21200"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -45,28 +46,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Xon-pC-cEy" customClass="GIFImageView" customModule="Gifu">
-                                <rect key="frame" x="137" y="378" width="140" height="140"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="140" id="cab-CK-51f"/>
-                                    <constraint firstAttribute="width" constant="140" id="kt4-lE-N6N"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레버를 스와이프하세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tfA-tz-Osk">
-                                <rect key="frame" x="128.5" y="581" width="157" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ylg-n1-Ety" customClass="GIFImageView" customModule="Gifu">
-                                <rect key="frame" x="107.5" y="305.5" width="199" height="285"/>
+                                <rect key="frame" x="107.5" y="275.5" width="199" height="285"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="285" id="vgt-Mf-g6t"/>
                                     <constraint firstAttribute="width" constant="199" id="x5g-EU-wIE"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DGD-4g-qoI">
-                                <rect key="frame" x="186" y="437.5" width="42" height="21"/>
+                                <rect key="frame" x="186" y="407.5" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -77,25 +65,51 @@
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TT7-ix-sna">
+                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레버를 스와이프하세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tfA-tz-Osk">
+                                        <rect key="frame" x="128.5" y="510" width="157" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Xon-pC-cEy" customClass="GIFImageView" customModule="Gifu">
+                                        <rect key="frame" x="137" y="307" width="140" height="140"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="140" id="cab-CK-51f"/>
+                                            <constraint firstAttribute="width" constant="140" id="kt4-lE-N6N"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="Xon-pC-cEy" firstAttribute="centerY" secondItem="TT7-ix-sna" secondAttribute="centerY" constant="-30" id="6mA-Hk-azZ"/>
+                                    <constraint firstItem="tfA-tz-Osk" firstAttribute="centerX" secondItem="TT7-ix-sna" secondAttribute="centerX" id="OuG-Vb-f1I"/>
+                                    <constraint firstItem="tfA-tz-Osk" firstAttribute="top" secondItem="Xon-pC-cEy" secondAttribute="bottom" constant="63" id="eco-yC-oGW"/>
+                                    <constraint firstItem="Xon-pC-cEy" firstAttribute="centerX" secondItem="TT7-ix-sna" secondAttribute="centerX" id="inp-xj-hxI"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="TuJ-cj-CBa"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="tfA-tz-Osk" firstAttribute="top" secondItem="Xon-pC-cEy" secondAttribute="bottom" constant="63" id="85a-Zm-Gra"/>
-                            <constraint firstItem="Xon-pC-cEy" firstAttribute="centerX" secondItem="FUu-e4-cQM" secondAttribute="centerX" id="Hx9-82-mSH"/>
                             <constraint firstItem="ylg-n1-Ety" firstAttribute="centerX" secondItem="FUu-e4-cQM" secondAttribute="centerX" id="KYq-Mq-ClF"/>
+                            <constraint firstItem="TT7-ix-sna" firstAttribute="top" secondItem="TuJ-cj-CBa" secondAttribute="top" id="KmI-3O-kTP"/>
+                            <constraint firstItem="TT7-ix-sna" firstAttribute="leading" secondItem="TuJ-cj-CBa" secondAttribute="leading" id="WGe-aa-B3Y"/>
                             <constraint firstItem="DGD-4g-qoI" firstAttribute="centerY" secondItem="ylg-n1-Ety" secondAttribute="centerY" id="Wkc-TX-zAA"/>
-                            <constraint firstItem="ylg-n1-Ety" firstAttribute="centerY" secondItem="FUu-e4-cQM" secondAttribute="centerY" id="XwQ-7C-JhU"/>
+                            <constraint firstItem="ylg-n1-Ety" firstAttribute="centerY" secondItem="FUu-e4-cQM" secondAttribute="centerY" constant="-30" id="XwQ-7C-JhU"/>
                             <constraint firstItem="TuJ-cj-CBa" firstAttribute="bottom" secondItem="LXg-aq-GeL" secondAttribute="bottom" constant="31" id="Zhx-Px-pm0"/>
-                            <constraint firstItem="Xon-pC-cEy" firstAttribute="centerY" secondItem="FUu-e4-cQM" secondAttribute="centerY" id="kke-vn-Ztu"/>
+                            <constraint firstItem="TuJ-cj-CBa" firstAttribute="trailing" secondItem="TT7-ix-sna" secondAttribute="trailing" id="mZc-iL-uQZ"/>
+                            <constraint firstItem="TuJ-cj-CBa" firstAttribute="bottom" secondItem="TT7-ix-sna" secondAttribute="bottom" id="peF-G0-Mfv"/>
                             <constraint firstItem="LXg-aq-GeL" firstAttribute="centerX" secondItem="FUu-e4-cQM" secondAttribute="centerX" id="qGJ-JQ-VtF"/>
-                            <constraint firstItem="tfA-tz-Osk" firstAttribute="centerX" secondItem="FUu-e4-cQM" secondAttribute="centerX" id="s9u-hb-krI"/>
                             <constraint firstItem="DGD-4g-qoI" firstAttribute="centerX" secondItem="FUu-e4-cQM" secondAttribute="centerX" id="t6h-0e-dXM"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="confirmButton" destination="LXg-aq-GeL" id="j4d-YS-C5B"/>
                         <outlet property="informationLabel" destination="tfA-tz-Osk" id="LCa-Nb-ref"/>
+                        <outlet property="joystickBackgroundView" destination="TT7-ix-sna" id="ty0-Xu-3IF"/>
                         <outlet property="joystickImageView" destination="Xon-pC-cEy" id="tyY-Eo-vpt"/>
                         <outlet property="nameLabel" destination="DGD-4g-qoI" id="Xc2-8y-TYT"/>
                         <outlet property="openCapsuleImageView" destination="ylg-n1-Ety" id="VQw-FC-2IF"/>

--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -97,7 +97,7 @@ final class SelectManittoViewController: BaseViewController {
             self.openCapsuleImageView.stopAnimatingGIF()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                     self.stageType = .openButton
-                })
+            })
         case .openButton:
             break
         }

--- a/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/SelectManittoViewController.swift
@@ -20,6 +20,7 @@ final class SelectManittoViewController: BaseViewController {
 
     // MARK: - property
 
+    @IBOutlet weak var joystickBackgroundView: UIView!
     @IBOutlet weak var joystickImageView: GIFImageView!
     @IBOutlet weak var informationLabel: UILabel!
     @IBOutlet weak var openCapsuleImageView: GIFImageView!
@@ -58,8 +59,6 @@ final class SelectManittoViewController: BaseViewController {
     override func configUI() {
         super.configUI()
 
-        joystickImageView.isUserInteractionEnabled = true
-
         informationLabel.font = .font(.regular, ofSize: 20)
         nameLabel.font = .font(.regular, ofSize: 30)
         nameLabel.text = manittiName
@@ -76,8 +75,8 @@ final class SelectManittoViewController: BaseViewController {
         swipeLeft.direction = UISwipeGestureRecognizer.Direction.left
         swipeRight.direction = UISwipeGestureRecognizer.Direction.right
 
-        joystickImageView.addGestureRecognizer(swipeLeft)
-        joystickImageView.addGestureRecognizer(swipeRight)
+        joystickBackgroundView.addGestureRecognizer(swipeLeft)
+        joystickBackgroundView.addGestureRecognizer(swipeRight)
     }
 
     private func setupGifImage() {
@@ -111,8 +110,7 @@ final class SelectManittoViewController: BaseViewController {
             confirmButton.isHidden = true
         case .capsule:
             openCapsuleImageView.isHidden = false
-            joystickImageView.isHidden = true
-            informationLabel.isHidden = true
+            joystickBackgroundView.isHidden = true
         case .openName:
             nameLabel.fadeIn()
         case .openButton:

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -154,6 +154,7 @@ class MainViewController: BaseViewController {
             self.niCharacterImageView.animate(withGIFNamed: ImageLiterals.gifNi, animationBlock: nil)
             self.ttoCharacterImageView.animate(withGIFNamed: ImageLiterals.gifTto, animationBlock: nil)
         }
+    }
 
     @objc func didTapSettingButton() {
         navigationController?.pushViewController(SettingViewController(), animated: true)


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #117 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
레버 스와이프 영역을 확장했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

Swipe Background View를 생성하고 그 위에 레버와 레버 라벨을 올렸습니다.
- Swipe Background View는 safe area로 영역을 잡았기 때문에 화면 전체에서 스와이프가 가능합니다.

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
![Simulator Screen Recording - iPhone 12 - 2022-08-14 at 16 35 53](https://user-images.githubusercontent.com/55099365/184527330-9a6f2b27-b98b-4dce-a90e-3a8440396774.gif)


