### PR TITLE
[FEAT] 최대 인원 Slider반영, 현재 인원보다적게 설정할 때 alert표시

### DIFF
--- a/Manito/Manito/Global/Extension/Notification+Extension.swift
+++ b/Manito/Manito/Global/Extension/Notification+Extension.swift
@@ -15,4 +15,5 @@ extension Notification.Name {
     static let checkNotification = Notification.Name("CheckNotification")
     static let dateRangeNotification = Notification.Name("DateRangeNotification")
     static let changeStartButtonNotification = Notification.Name("ChangeStartButtonNotification")
+    static let editMaxUserNotification = Notification.Name("EditMaxUserNotification")
 }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -248,8 +248,9 @@ class DetailEditViewController: BaseViewController {
 
     private func setupChangedButton() {
         calendarView.changeButtonState = { [weak self] value in
-            self?.changeButton.isUserInteractionEnabled = value
-            self?.changeButton.setTitleColor(value ? .subBlue : .grey002, for: .normal)
+            self?.changeButton.isEnabled = value
+            self?.changeButton.setTitleColor(.subBlue, for: .normal)
+            self?.changeButton.setTitleColor(.grey002, for: .disabled)
         }
     }
 

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -55,15 +55,10 @@ class DetailEditViewController: BaseViewController {
     private lazy var changeButton: UIButton = {
         let button = UIButton(type: .system)
         let buttonAction = UIAction { [weak self] _ in
-            guard let startText = self?.calendarView.tempStartDateText else { return }
-            guard let endText = self?.calendarView.tempEndDateText else { return }
-            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startText, "endDate": endText])
-            NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
-            self?.dismiss(animated: true)
+            self?.didTapChangeButton()
         }
         button.setTitle("변경", for: .normal)
         button.setTitleColor(.subBlue, for: .normal)
-        setChangedButton()
         button.titleLabel?.font = .font(.regular, ofSize: 16)
         button.addAction(buttonAction, for: .touchUpInside)
         return button
@@ -137,6 +132,7 @@ class DetailEditViewController: BaseViewController {
         self.navigationController?.isNavigationBarHidden = true
         self.presentationController?.delegate = self
         isModalInPresentation = true
+        setupChangedButton()
     }
 
     override func render() {
@@ -251,11 +247,17 @@ class DetailEditViewController: BaseViewController {
         makeActionSheet(actionTitles: actionTitles, actionStyle: actionStyle, actions: actions)
     }
 
-    private func setChangedButton() {
+    private func setupChangedButton() {
         calendarView.changeButtonState = { [weak self] value in
             self?.changeButton.isUserInteractionEnabled = value
             self?.changeButton.setTitleColor(value ? .subBlue : .grey002, for: .normal)
         }
+    }
+    
+    private func didTapChangeButton() {
+        NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
+        NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
+        dismiss(animated: true)
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -16,7 +16,7 @@ class DetailEditViewController: BaseViewController {
         case dateEditMode
         case infoEditMode
     }
-    var editMode: EditMode = .infoEditMode
+    var editMode: EditMode
     var currentUserCount = 0
     var sliderValue = 10
     var startDateText = "" {
@@ -125,7 +125,16 @@ class DetailEditViewController: BaseViewController {
     }()
 
     // MARK: - life cycle
-
+    
+    init(editMode: EditMode) {
+        self.editMode = editMode
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func configUI() {
         super.configUI()
         self.navigationController?.isNavigationBarHidden = true

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -273,14 +273,14 @@ class DetailEditViewController: BaseViewController {
     }
 
     private func changeRoomDateRange() {
-        NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
+        NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.getTempStartDate(), "endDate": calendarView.getTempEndDate()])
         NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
         dismiss(animated: true)
     }
 
     private func changeRoomInfo() {
         if currentUserCount <= sliderValue {
-            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
+            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.getTempStartDate(), "endDate": calendarView.getTempEndDate()])
             NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
             NotificationCenter.default.post(name: .editMaxUserNotification, object: nil, userInfo: ["maxUser": memberSlider.value])
             dismiss(animated: true)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -16,11 +16,10 @@ class DetailEditViewController: BaseViewController {
         case dateEditMode
         case infoEditMode
     }
-    var sliderValue = 0
+    var sliderValue = 15
 
     var editMode: EditMode = .infoEditMode
 
-    private var memberCount = 7
     var startDateText = "" {
         didSet {
             calendarView.startDateText = startDateText
@@ -112,7 +111,7 @@ class DetailEditViewController: BaseViewController {
         slider.maximumValue = 15
         slider.maximumTrackTintColor = .darkGrey003
         slider.minimumTrackTintColor = .red001
-        slider.value = Float(memberCount)
+        slider.value = Float(sliderValue)
         slider.isContinuous = true
         slider.setThumbImage(ImageLiterals.imageSliderThumb, for: .normal)
         slider.addTarget(self, action: #selector(changeMemberCount(sender:)), for: .valueChanged)
@@ -120,7 +119,7 @@ class DetailEditViewController: BaseViewController {
     }()
     private lazy var memberCountLabel: UILabel = {
         let label = UILabel()
-        label.text = "\(memberCount)인"
+        label.text = "\(sliderValue)인"
         label.font = .font(.regular, ofSize: 24)
         label.textColor = .white
         return label

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -16,10 +16,9 @@ class DetailEditViewController: BaseViewController {
         case dateEditMode
         case infoEditMode
     }
-    var sliderValue = 15
-
     var editMode: EditMode = .infoEditMode
-
+    var currentUserCount = 0
+    var sliderValue = 10
     var startDateText = "" {
         didSet {
             calendarView.startDateText = startDateText
@@ -222,6 +221,7 @@ class DetailEditViewController: BaseViewController {
 
     @objc
     private func changeMemberCount(sender: UISlider) {
+        sliderValue = Int(sender.value)
         memberCountLabel.text = String(Int(sender.value)) + "인"
         memberCountLabel.font = .font(.regular, ofSize: 24)
         memberCountLabel.textColor = .white
@@ -234,7 +234,6 @@ class DetailEditViewController: BaseViewController {
             dismiss(animated: true)
             return
         }
-        
         showDiscardChangAlert()
     }
 
@@ -253,12 +252,31 @@ class DetailEditViewController: BaseViewController {
             self?.changeButton.setTitleColor(value ? .subBlue : .grey002, for: .normal)
         }
     }
-    
+
     private func didTapChangeButton() {
+        switch editMode {
+        case .dateEditMode:
+            changeRoomDateRange()
+        case .infoEditMode:
+            changeRoomInfo()
+        }
+    }
+
+    private func changeRoomDateRange() {
         NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
         NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
-        NotificationCenter.default.post(name: .editMaxUserNotification, object: nil, userInfo: ["maxUser": memberSlider.value])
         dismiss(animated: true)
+    }
+
+    private func changeRoomInfo() {
+        if currentUserCount <= sliderValue {
+            NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
+            NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
+            NotificationCenter.default.post(name: .editMaxUserNotification, object: nil, userInfo: ["maxUser": memberSlider.value])
+            dismiss(animated: true)
+        } else {
+            makeAlert(title: "인원을 다시 설정해 주세요", message: "현재 인원보다 최대 인원을 \n더 적게 설정할 수 없어요.")
+        }
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -16,6 +16,7 @@ class DetailEditViewController: BaseViewController {
         case dateEditMode
         case infoEditMode
     }
+    var sliderValue = 0
 
     var editMode: EditMode = .infoEditMode
 
@@ -257,6 +258,7 @@ class DetailEditViewController: BaseViewController {
     private func didTapChangeButton() {
         NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": calendarView.tempStartDateText, "endDate": calendarView.tempEndDateText])
         NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
+        NotificationCenter.default.post(name: .editMaxUserNotification, object: nil, userInfo: ["maxUser": memberSlider.value])
         dismiss(animated: true)
     }
 }

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -347,9 +347,9 @@ class DetailWaitViewController: BaseViewController {
                     let endDate = (Date() + fiveDaysInterval).dateToString
                     self?.presentModal(from: startDate, to: endDate, isDateEdit: true)
                 }
-                makeAlert(title: "날짜를 재설정 해주세요", message: "마니또 시작일이 지났습니다. \n 진행기간을 재설정 해주세요", okAction: action)
+                makeAlert(title: "마니또 시작일이 지났어요", message: "진행기간을 재설정 해주세요", okAction: action)
             } else {
-                makeAlert(title: "시작일이 지났어요", message: "방장이 진행기간을 재설정 \n 할 때까지 기다려주세요")
+                makeAlert(title: "마니또 시작일이 지났어요", message: "방장이 진행기간을 재설정 \n 할 때까지 기다려주세요.")
             }
         }
     }

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 class DetailWaitViewController: BaseViewController {
     let userArr = ["호야", "리비", "듀나", "코비", "디너", "케미"]
     var canStartClosure: ((Bool) -> ())?
-    var maxUserCount: Int = 15 {
+    var maxUserCount: Int = 10 {
         didSet {
             comeInLabel.text = "\(userCount)/\(maxUserCount)"
         }
@@ -264,12 +264,13 @@ class DetailWaitViewController: BaseViewController {
     }
 
     private func presentModal(from startString: String, to endString: String, isDateEdit: Bool) {
-        let modalViewController = DetailEditViewController()
-        modalViewController.sliderValue = maxUserCount
-        modalViewController.editMode = isDateEdit ? .dateEditMode : .infoEditMode
-        modalViewController.startDateText = startString
-        modalViewController.endDateText = endString
-        present(modalViewController, animated: true, completion: nil)
+        let viewController = DetailEditViewController()
+        viewController.currentUserCount = userCount
+        viewController.sliderValue = maxUserCount
+        viewController.editMode = isDateEdit ? .dateEditMode : .infoEditMode
+        viewController.startDateText = startString
+        viewController.endDateText = endString
+        present(viewController, animated: true, completion: nil)
     }
 
     // MARK: - private func

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -264,10 +264,9 @@ class DetailWaitViewController: BaseViewController {
     }
 
     private func presentModal(from startString: String, to endString: String, isDateEdit: Bool) {
-        let viewController = DetailEditViewController()
+        let viewController = DetailEditViewController(editMode: isDateEdit ? .dateEditMode : .infoEditMode)
         viewController.currentUserCount = userCount
         viewController.sliderValue = maxUserCount
-        viewController.editMode = isDateEdit ? .dateEditMode : .infoEditMode
         viewController.startDateText = startString
         viewController.endDateText = endString
         present(viewController, animated: true, completion: nil)

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -368,10 +368,8 @@ class DetailWaitViewController: BaseViewController {
 
     @objc
     private func didReceiveDateRange(_ notification: Notification) {
-        guard let noti = notification.userInfo else { return }
-
-        guard let startDate = noti["startDate"] as? String else { return }
-        guard let endDate = noti["endDate"] as? String else { return }
+        guard let startDate = notification.userInfo?["startDate"] as? String else { return }
+        guard let endDate = notification.userInfo?["endDate"] as? String else { return }
 
         self.startDateText = startDate
         self.endDateText = endDate
@@ -379,9 +377,7 @@ class DetailWaitViewController: BaseViewController {
 
     @objc
     private func didReceiveMaxUser(_ notification: Notification) {
-        guard let noti = notification.userInfo else { return }
-
-        guard let maxUser = noti["maxUser"] as? Float else { return }
+        guard let maxUser = notification.userInfo?["maxUser"] as? Float else { return }
 
         let intMaxUser = Int(maxUser)
         maxUserCount = intMaxUser

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -12,7 +12,11 @@ import SnapKit
 class DetailWaitViewController: BaseViewController {
     let userArr = ["호야", "리비", "듀나", "코비", "디너", "케미"]
     var canStartClosure: ((Bool) -> ())?
-    var maxUserCount: ((Int) -> ())?
+    var maxUserCount: Int = 15 {
+        didSet {
+            comeInLabel.text = "\(userCount)/\(maxUserCount)"
+        }
+    }
     lazy var userCount = userArr.count
     let isOwner = true
     var startDateText = "22.08.11" {
@@ -106,12 +110,9 @@ class DetailWaitViewController: BaseViewController {
     }()
     private lazy var comeInLabel: UILabel = {
         let label = UILabel()
-        maxUserCount = { [weak self] value in
-            guard let count = self?.userCount else { return }
-            label.text = "\(count)/\(value)"
-            label.textColor = .white
-            label.font = .font(.regular, ofSize: 14)
-        }
+        label.text = "\(userCount)/\(maxUserCount)"
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 14)
         return label
     }()
     private lazy var copyButton: UIButton = {
@@ -165,7 +166,6 @@ class DetailWaitViewController: BaseViewController {
         setupNotificationCenter()
         isPastStartDate()
         setStartButton()
-        setupMaxUserCount()
     }
 
     override func render() {
@@ -265,6 +265,7 @@ class DetailWaitViewController: BaseViewController {
 
     private func presentModal(from startString: String, to endString: String, isDateEdit: Bool) {
         let modalViewController = DetailEditViewController()
+        modalViewController.sliderValue = maxUserCount
         modalViewController.editMode = isDateEdit ? .dateEditMode : .infoEditMode
         modalViewController.startDateText = startString
         modalViewController.endDateText = endString
@@ -362,10 +363,6 @@ class DetailWaitViewController: BaseViewController {
         canStartClosure?(isToday)
     }
 
-    private func setupMaxUserCount() {
-        maxUserCount?(15)
-    }
-
     // MARK: - selector
 
     @objc
@@ -386,7 +383,7 @@ class DetailWaitViewController: BaseViewController {
         guard let maxUser = noti["maxUser"] as? Float else { return }
 
         let intMaxUser = Int(maxUser)
-        maxUserCount?(intMaxUser)
+        maxUserCount = intMaxUser
     }
     
     @objc

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -190,7 +190,7 @@ extension CalendarView: FSCalendarDelegate {
             tempEndDateText = date.dateToString
             if countDateRange() > 7 {
                 calendar.deselect(date)
-                viewController?.makeAlert(title: "설정 기간 제한", message: "최대 7일까지 선택가능해요 !")
+                viewController?.makeAlert(title: "최대 선택 기간을 넘었어요", message: "최대 7일까지 선택가능해요")
             } else {
                 setDateRange()
                 calendar.reloadData()
@@ -222,7 +222,7 @@ extension CalendarView: FSCalendarDelegate {
 
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
         if date < Date() - oneDayInterval {
-            viewController?.makeAlert(title: "과거로 가시게요..?", message: "오늘보다 이전 날짜는 \n 선택하실 수 없어요 !")
+            viewController?.makeAlert(title: "지난 날을 선택하셨어요", message: "오늘보다 이전 날짜는 \n 선택하실 수 없어요")
             return false
         } else {
             return true


### PR DESCRIPTION
## 🟣 관련 이슈
- close #144 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 대기방에서 최대 인원이랑 UISlider랑 연결이 안되어있었고, 값을 변경해도 반영이 되지 않은 문데를 해결했습니다.
- 방 정보 수정에서 현재 참가한 인원보다 더 적게 최대 인원을 설정할 때 alert 표시를 했습니다
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

++ API연결할 때 방 정보 수정할 때 찰나에 현재인원이 추가되진 않았는지 확인하는 작업이 필요해 보입니다.
## 🟣 PR Point
DetailEditViewController에 265~280 번째 줄에 중복되는 코드가 있는데 하나의 함수로 빼는게 좋을까요 ??
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

https://user-images.githubusercontent.com/78677571/185624868-5049fb9e-a28b-4a41-9af9-49008a02c77d.mp4



<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

