### PR TITLE
[FEAT] 방 생성뷰 캘린더 기능 추가

### DIFF
--- a/Manito/Manito/Screens/CreateRoom/Component/CheckRoomView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/CheckRoomView.swift
@@ -11,8 +11,8 @@ import SnapKit
 
 class CheckRoomView: UIView {
     var dateRange = "" {
-        didSet {
-            dateLabel.text = dateRange
+        willSet {
+            dateLabel.text = newValue
         }
     }
 

--- a/Manito/Manito/Screens/CreateRoom/Component/CheckRoomView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/CheckRoomView.swift
@@ -10,6 +10,11 @@ import UIKit
 import SnapKit
 
 class CheckRoomView: UIView {
+    var dateRange = "" {
+        didSet {
+            dateLabel.text = dateRange
+        }
+    }
 
     // MARK: - Property
     

--- a/Manito/Manito/Screens/CreateRoom/Component/InputDateView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputDateView.swift
@@ -33,26 +33,10 @@ class InputDateView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
-        tapGesture()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Funtion
-    
-    private func tapGesture() {
-        let gestureTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapDateBackView(_:)))
-        gestureTapRecognizer.numberOfTapsRequired = 1
-        gestureTapRecognizer.numberOfTouchesRequired = 1
-        self.addGestureRecognizer(gestureTapRecognizer)
-    }
-    
-    // MARK: - Selector
-    
-    @objc private func didTapDateBackView(_ gesture: UITapGestureRecognizer) {
-        print("gesture")
     }
     
     // MARK: - Config

--- a/Manito/Manito/Screens/CreateRoom/Component/InputDateView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputDateView.swift
@@ -19,7 +19,7 @@ class InputDateView: UIView {
         label.font = .font(.regular, ofSize: 18)
         return label
     }()
-    private let calendarView = CalendarView()
+    let calendarView = CalendarView()
     private let dateInfoLabel: UILabel = {
         let label = UILabel()
         label.text = "최대 7일까지 설정할 수 있어요 !"

--- a/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
+++ b/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
@@ -155,7 +155,7 @@ class CreateRoomViewController: BaseViewController {
         case 1:
             person = Int(personView.personSlider.value)
         case 2:
-            checkView.dateRange = "\(dateView.calendarView.getTempStartDate()) ~ \(dateView.calendarView.getTemptEndDate())"
+            checkView.dateRange = "\(dateView.calendarView.getTempStartDate()) ~ \(dateView.calendarView.getTempEndDate())"
             print("기간 선택 보여주기")
         default:
             print("다른 뷰 넘기기")

--- a/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
+++ b/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
@@ -155,6 +155,7 @@ class CreateRoomViewController: BaseViewController {
         case 1:
             person = Int(personView.personSlider.value)
         case 2:
+            checkView.dateRange = "\(dateView.calendarView.getTempStartDate()) ~ \(dateView.calendarView.getTemptEndDate())"
             print("기간 선택 보여주기")
         default:
             print("다른 뷰 넘기기")

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -55,8 +55,8 @@ class DetailEditViewController: BaseViewController {
     private lazy var changeButton: UIButton = {
         let button = UIButton(type: .system)
         let buttonAction = UIAction { [weak self] _ in
-            guard let startText = self?.calendarView.tempStartDateText else { return }
-            guard let endText = self?.calendarView.tempEndDateText else { return }
+            guard let startText = self?.calendarView.getTempStartDate() else { return }
+            guard let endText = self?.calendarView.getTemptEndDate() else { return }
             NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startText, "endDate": endText])
             NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
             self?.dismiss(animated: true)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -56,7 +56,7 @@ class DetailEditViewController: BaseViewController {
         let button = UIButton(type: .system)
         let buttonAction = UIAction { [weak self] _ in
             guard let startText = self?.calendarView.getTempStartDate() else { return }
-            guard let endText = self?.calendarView.getTemptEndDate() else { return }
+            guard let endText = self?.calendarView.getTempEndDate() else { return }
             NotificationCenter.default.post(name: .dateRangeNotification, object: nil, userInfo: ["startDate": startText, "endDate": endText])
             NotificationCenter.default.post(name: .changeStartButtonNotification, object: nil)
             self?.dismiss(animated: true)

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -11,10 +11,10 @@ import FSCalendar
 import SnapKit
 
 class CalendarView: UIView {
-    var changeButtonState: ((Bool) -> ())?
     private var selectStartDate = Date()
-    let oneDayInterval: TimeInterval = 86400
-    let sevenDaysInterval: TimeInterval = 604800
+    private let oneDayInterval: TimeInterval = 86400
+    private let sevenDaysInterval: TimeInterval = 604800
+    var changeButtonState: ((Bool) -> ())?
     var startDateText = ""
     var endDateText = ""
     var tempStartDateText = ""

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -17,8 +17,8 @@ class CalendarView: UIView {
     var changeButtonState: ((Bool) -> ())?
     var startDateText = ""
     var endDateText = ""
-    var tempStartDateText = ""
-    var tempEndDateText = ""
+    private var tempStartDateText = ""
+    private var tempEndDateText = ""
     var isFirstTap = false
     
     private enum CalendarMoveType {
@@ -163,6 +163,14 @@ class CalendarView: UIView {
         let dateRangeCount = selectdDate / 86400
 
         return Int(dateRangeCount) + 1
+    }
+    
+    func getTempStartDate() -> String {
+        return tempStartDateText
+    }
+    
+    func getTemptEndDate() -> String {
+        return tempEndDateText
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -169,7 +169,7 @@ class CalendarView: UIView {
         return tempStartDateText
     }
     
-    func getTemptEndDate() -> String {
+    func getTempEndDate() -> String {
         return tempEndDateText
     }
 }
@@ -235,9 +235,7 @@ extension CalendarView: FSCalendarDelegate {
         let isDoneSelectedDate = calendar.selectedDates.count > 2
         if isBeforeToday {
             return .grey004.withAlphaComponent(0.4)
-        } else if !isFirstTap {
-            return .white
-        } else if isAWeekBeforeAfter || isDoneSelectedDate {
+        } else if !isFirstTap || (isAWeekBeforeAfter || isDoneSelectedDate) {
             return .white
         } else {
             return .grey004.withAlphaComponent(0.4)

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -170,9 +170,14 @@ extension CalendarView: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         isFirstTap = true
         changeButtonState?(false)
+        let isCreatedRoomOnlySelectedStartDate = calendar.selectedDates.count == 1
         let isSelectedDateRange = calendar.selectedDates.count == 2
         let isReclickedStartDate = calendar.selectedDates.count > 2
-        if isSelectedDateRange {
+        if isCreatedRoomOnlySelectedStartDate {
+            selectStartDate = date
+            calendar.select(selectStartDate)
+            calendar.reloadData()
+        } else if isSelectedDateRange {
             changeButtonState?(true)
             tempEndDateText = date.dateToString
             if countDateRange() > 7 {
@@ -222,6 +227,8 @@ extension CalendarView: FSCalendarDelegate {
         let isDoneSelectedDate = calendar.selectedDates.count > 2
         if isBeforeToday {
             return .grey004.withAlphaComponent(0.4)
+        } else if !isFirstTap {
+            return .white
         } else if isAWeekBeforeAfter || isDoneSelectedDate {
             return .white
         } else {


### PR DESCRIPTION
## 🟣 관련 이슈
- close #146 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 방 생성뷰에서 시작날짜와 끝나는 날짜를 선택할 수 있습니다.
- 기존에 구현해둔 캘린더를 사용했습니다.
- 그 과정에서 캘린더의 기능을 조금 추가했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- 스누피와 듀나의 조언대로 calendarView의 변수에 private를 주고 함수를 만들어서 내부 변수에 접근하도록 만들었습니다. 함수명에 get을 사용했는데 컨벤션에 혹시 어긋날까요 ??
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

https://user-images.githubusercontent.com/78677571/186101241-8d248c2f-4030-4d85-852f-ad8152f630d8.mp4


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

