### PR TITLE
[FEAT] Letter View Spacing 변경 및 dynamic height 오류 해결

### DIFF
--- a/Manito/Manito/Screens/Letter/Cell/LetterCollectionViewCell.swift
+++ b/Manito/Manito/Screens/Letter/Cell/LetterCollectionViewCell.swift
@@ -50,19 +50,6 @@ final class LetterCollectionViewCell: BaseCollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        super.preferredLayoutAttributesFitting(layoutAttributes)
-        layoutIfNeeded()
-        
-        let size = contentView.systemLayoutSizeFitting(layoutAttributes.size)
-        var frame = layoutAttributes.frame
-        
-        frame.size.height = ceil(size.height)
-        layoutAttributes.frame = frame
-        
-        return layoutAttributes
-    }
-    
     override func prepareForReuse() {
         contentLabel.text = nil
         photoImageView.image = nil

--- a/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
@@ -80,20 +80,20 @@ final class CreateLetterViewController: BaseViewController {
         scrollContentView.addSubview(missionView)
         missionView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(25)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
             $0.height.equalTo(100)
         }
         
         scrollContentView.addSubview(letterTextView)
         letterTextView.snp.makeConstraints {
             $0.top.equalTo(missionView.snp.bottom).offset(32)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
         }
         
         scrollContentView.addSubview(letterPhotoView)
         letterPhotoView.snp.makeConstraints {
             $0.top.equalTo(letterTextView.snp.bottom).offset(22)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
             $0.bottom.equalToSuperview().inset(105)
         }
     }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -27,10 +27,13 @@ final class LetterViewController: BaseViewController {
     
     private enum Size {
         static let headerHeight: CGFloat = 66.0
-        static let emptyContentHeight: CGFloat = 48.0
         static let collectionHorizontalSpacing: CGFloat = 20.0
         static let collectionVerticalSpacing: CGFloat = 18.0
+        static let cellTopSpacing: CGFloat = 16.0
+        static let cellBottomSpacing: CGFloat = 35.0
+        static let cellHorizontalSpacing: CGFloat = 16.0
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - collectionHorizontalSpacing * 2
+        static let imageHeight: CGFloat = 204.0
         static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,
@@ -45,7 +48,6 @@ final class LetterViewController: BaseViewController {
         flowLayout.sectionInset = Size.collectionInset
         flowLayout.minimumLineSpacing = 33
         flowLayout.sectionHeadersPinToVisibleBounds = true
-        flowLayout.estimatedItemSize = CGSize(width: Size.cellWidth, height: Size.emptyContentHeight)
         return flowLayout
     }()
     private lazy var listCollectionView: UICollectionView = {
@@ -130,6 +132,19 @@ final class LetterViewController: BaseViewController {
         listCollectionView.collectionViewLayout.invalidateLayout()
         listCollectionView.reloadData()
     }
+    
+    private func calculateContentHeight(text: String) -> CGFloat {
+        let width = UIScreen.main.bounds.size.width - Size.collectionHorizontalSpacing * 2 - Size.cellHorizontalSpacing * 2
+        let label = UILabel(frame: CGRect(origin: .zero,
+                                          size: CGSize(width: width,
+                                                       height: .greatestFiniteMagnitude)))
+        label.text = text
+        label.font = .font(.regular, ofSize: 15)
+        label.numberOfLines = 0
+        label.addLabelSpacing()
+        label.sizeToFit()
+        return label.frame.height
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -164,6 +179,20 @@ extension LetterViewController: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegate
 extension LetterViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        var heights = [Size.cellTopSpacing, Size.cellBottomSpacing]
+        
+        if let content = letterState.lists[indexPath.item].content {
+            heights += [calculateContentHeight(text: content)]
+        }
+        
+        if letterState.lists[indexPath.item].image != nil {
+            heights += [Size.imageHeight]
+        }
+        
+        return CGSize(width: Size.cellWidth, height: heights.reduce(0, +))
+    }
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return CGSize(width: UIScreen.main.bounds.size.width, height: Size.headerHeight)
     }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -28,7 +28,7 @@ final class LetterViewController: BaseViewController {
     private enum Size {
         static let headerHeight: CGFloat = 66.0
         static let emptyContentHeight: CGFloat = 48.0
-        static let collectionHorizontalSpacing: CGFloat = 16.0
+        static let collectionHorizontalSpacing: CGFloat = 20.0
         static let collectionVerticalSpacing: CGFloat = 18.0
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - collectionHorizontalSpacing * 2
         static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,

--- a/Manito/Manito/Screens/Letter/UIComponent/LetterHeaderView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/LetterHeaderView.swift
@@ -54,7 +54,7 @@ final class LetterHeaderView: UICollectionReusableView {
         self.addSubview(segmentControl)
         segmentControl.snp.makeConstraints {
             $0.top.bottom.equalToSuperview().inset(13)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
             $0.height.equalTo(40)
         }
     }

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -154,6 +154,7 @@ class MainViewController: BaseViewController {
             self.niCharacterImageView.animate(withGIFNamed: ImageLiterals.gifNi, animationBlock: nil)
             self.ttoCharacterImageView.animate(withGIFNamed: ImageLiterals.gifTto, animationBlock: nil)
         }
+    }
 
     @objc func didTapSettingButton() {
         navigationController?.pushViewController(SettingViewController(), animated: true)
@@ -231,7 +232,7 @@ extension MainViewController: UICollectionViewDelegateFlowLayout {
         if indexPath.item == 0 {
             newRoom()
         } else {
-            pushDetailView(status: .waiting)
+            pushDetailView(status: .starting)
         }
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #142 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- Letter View Controller Spacing 변경
- Letter View에서 Collection View의 레이아웃이 자꾸 무너지는 문제가 생겨서(prepareForReuse 때문) 이 부분을 수정했습니다.
   - CollectionView Cell의 높이를 미리 계산해서 정하는 방식으로 진행했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- Spacing를 20으로 변경했습니다.
- Cell의 높이가 동적으로 바뀌는 데 전에는 `preferredLayoutAttributesFitting`메소드를 써서 해당 부분을 구현했었습니다. 하지만 메소드가 Layout를 처음 한 번만 잡아주어서 Reuse될 때 높이가 다 망가지더라구요. 그 부분을 고치기 위해서 CollectionViewFlowLayoutDelegate 안에 있는 itemSize 부분에서 매번 각 셀의 높이를 잡아줄 수 있도록 구현했습니다. 지금은 잘 구동됩니다.

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->


https://user-images.githubusercontent.com/55099365/186290435-c7bba155-dc23-47ac-9be2-acbe560320e7.mp4


