### PR TITLE
[FEAT] 끝난 방이라면 쪽지 전송 뷰로 이동하지 못하도록 구현 완료

### DIFF
--- a/Manito/Manito/Global/Resource/Storyboards/Letter.storyboard
+++ b/Manito/Manito/Global/Resource/Storyboards/Letter.storyboard
@@ -8,22 +8,6 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Letter View Controller-->
-        <scene sceneID="s0d-6b-0kx">
-            <objects>
-                <viewController storyboardIdentifier="LetterViewController" id="Y6W-OH-hqX" customClass="LetterViewController" customModule="Manito" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </view>
-                    <navigationItem key="navigationItem" id="VAt-mZ-qJ6"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="971.01449275362324" y="105.80357142857143"/>
-        </scene>
         <!--Create Letter View Controller-->
         <scene sceneID="YQI-Gc-gP8">
             <objects>
@@ -43,7 +27,6 @@
         <!--Navigation Controller-->
         <scene sceneID="MRp-N2-TO2">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="2RJ-7d-4Xd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <navigationController storyboardIdentifier="CreateLetterNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="4Ti-HA-7f9" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="866-Cc-mkB">
@@ -55,6 +38,7 @@
                         <segue destination="wwe-Dx-Lxd" kind="relationship" relationship="rootViewController" id="d1v-Dy-7Cn"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2RJ-7d-4Xd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2215.9420289855075" y="105.80357142857143"/>
         </scene>

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -140,7 +140,9 @@ class DetailIngViewController: BaseViewController {
     
     private func addActionPushLetterViewController() {
         let action = UIAction { [weak self] _ in
-            self?.navigationController?.pushViewController(LetterViewController(), animated: true)
+            // TODO: - POST로 지정해두었기 때문에 들어오는 값에 따라서 다른 값이 들어오도록 해야 함
+            let letterViewController = LetterViewController(roomState: "POST")
+            self?.navigationController?.pushViewController(letterViewController, animated: true)
         }
         letterBoxButton.addAction(action, for: .touchUpInside)
     }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -63,12 +63,24 @@ final class LetterViewController: BaseViewController {
                                 withReuseIdentifier: LetterHeaderView.className)
         return collectionView
     }()
-    private let sendLetterView = SendLetterView()
+    private lazy var sendLetterView = SendLetterView()
     
     private var letterState: LetterState = .sent {
         didSet {
             reloadCollectionView(with: self.letterState)
         }
+    }
+    private var roomState: String
+    
+    // MARK: - init
+    
+    init(roomState: String) {
+        self.roomState = roomState
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - life cycle
@@ -93,14 +105,16 @@ final class LetterViewController: BaseViewController {
             $0.bottom.equalToSuperview()
         }
         
-        view.addSubview(sendLetterView)
-        sendLetterView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
-        
         view.addSubview(guideButton)
         guideButton.snp.makeConstraints {
             $0.width.height.equalTo(44)
+        }
+        
+        if roomState != "POST" {
+            view.addSubview(sendLetterView)
+            sendLetterView.snp.makeConstraints {
+                $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            }
         }
     }
     


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #176 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
끝난 방이라면 ViewController로 들어올 때 Type으로 String값을 받아서 하단 쪽지 생성 뷰로 이어지는 버튼이 생성되지 않도록 구현했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- "POST"라는 단어가 들어오면 하단 쪽지 생성 뷰로 넘어가는 버튼이 레이아웃을 잡지 않도록 했습니다.
   - `lazy var`로 설정했습니다.

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

detail-ing에서 연결해서 밖 뷰는 끝난 상태가 아닙니다. 테스트한 것!

https://user-images.githubusercontent.com/55099365/187695067-f279e317-9194-47f4-af79-348cbd1fd1ae.MP4




