### PR TITLE
[FEAT] 마니또 시작가능 조건 적용, 최대 인원 API반영

### DIFF
--- a/Manito/Manito/Network/Models/Room.swift
+++ b/Manito/Manito/Network/Models/Room.swift
@@ -47,7 +47,7 @@ struct User: Decodable {
 
 // MARK: - Room
 struct RoomInfo: Decodable {
-    let id: Int?
+    let id, capacity: Int?
     let title, startDate, endDate, state: String?
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -20,7 +20,7 @@ class DetailWaitViewController: BaseViewController {
         }
     }
     var canStartClosure: ((Bool) -> ())?
-    var maxUserCount: Int = 10 {
+    var maxUserCount: Int = 15 {
         didSet {
             comeInLabel.text = "\(userCount)/\(maxUserCount)"
         }
@@ -263,6 +263,7 @@ class DetailWaitViewController: BaseViewController {
                           let code = roomInfo.invitation?.code,
                           let startDate = roomInfo.room?.startDate,
                           let endDate = roomInfo.room?.endDate,
+                          let capacity = roomInfo.room?.capacity,
                           let state = roomInfo.room?.state,
                           let members = roomInfo.participants?.members,
                           let isAdmin = roomInfo.admin else { return }
@@ -270,6 +271,7 @@ class DetailWaitViewController: BaseViewController {
                     inviteCode = code
                     startDateText = startDate
                     endDateText = endDate
+                    maxUserCount = capacity
                     titleView.setStartState(state: state)
                     userArr = members.map { $0.nickname ?? "" }
                     isOwner = isAdmin

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -16,7 +16,6 @@ class DetailWaitViewController: BaseViewController {
     private var userArr: [String] = [] {
         didSet {
             renderTableView()
-            userCount = userArr.count
         }
     }
     var canStartClosure: ((Bool) -> ())?
@@ -28,6 +27,7 @@ class DetailWaitViewController: BaseViewController {
     lazy var userCount = 0 {
         didSet {
             comeInLabel.text = "\(userCount)/\(maxUserCount)"
+            setStartButton()
         }
     }
     var isOwner = false {
@@ -263,6 +263,7 @@ class DetailWaitViewController: BaseViewController {
                           let code = roomInfo.invitation?.code,
                           let startDate = roomInfo.room?.startDate,
                           let endDate = roomInfo.room?.endDate,
+                          let count = roomInfo.participants?.count,
                           let capacity = roomInfo.room?.capacity,
                           let state = roomInfo.room?.state,
                           let members = roomInfo.participants?.members,
@@ -271,6 +272,7 @@ class DetailWaitViewController: BaseViewController {
                     inviteCode = code
                     startDateText = startDate
                     endDateText = endDate
+                    userCount = count
                     maxUserCount = capacity
                     titleView.setStartState(state: state)
                     userArr = members.map { $0.nickname ?? "" }
@@ -466,8 +468,9 @@ class DetailWaitViewController: BaseViewController {
         guard let todayDate = Date().dateToString.stringToDate else { return }
         
         let isToday = startDate.distance(to: todayDate).isZero
-        
-        canStartClosure?(isToday)
+        let isMinimumUserCount = userCount >= 5
+
+        canStartClosure?(isToday && isMinimumUserCount)
     }
     
     private func renderTableView() {


### PR DESCRIPTION
## 🟣 관련 이슈
- close #199 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 마니또 시작가능 조건이 날짜가 오늘일때로 설정이 되어있었는데, 오늘일 때 && 최소 5명이상일 때 로 변경했습니다.
- 최대 인원이 api에서 값이 리턴되지 않아서 작업 못했던 부분을 연결 작업했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

https://user-images.githubusercontent.com/78677571/188566081-57e5a356-e09c-4743-8e98-634f3a7472ba.mp4


