### PR TITLE
[FEAT] 닉네임 변경하기 유저디폴트 관리, 서버에 보내기

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -140,8 +140,12 @@
 		CBBFF77C287AE491006A5964 /* DeveloperInfoViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBFF77B287AE491006A5964 /* DeveloperInfoViewCell.swift */; };
 		D724AF5D287088310003F280 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724AF5C287088310003F280 /* SettingViewController.swift */; };
 		D724AF5F28708D830003F280 /* ImageRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D724AF5E28708D830003F280 /* ImageRowView.swift */; };
+		D739C36328C7B69D00161117 /* SettingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D739C36228C7B69D00161117 /* SettingProtocol.swift */; };
+		D739C36528C7B75400161117 /* SettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D739C36428C7B75400161117 /* SettingAPI.swift */; };
+		D739C36728C7B82500161117 /* NicknameDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D739C36628C7B82500161117 /* NicknameDTO.swift */; };
 		D77224DF285DDAB7008B760B /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77224DE285DDAB7008B760B /* Notification+Extension.swift */; };
 		D777D2C928C7780E008655BD /* UrlLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D777D2C828C7780E008655BD /* UrlLiteral.swift */; };
+		D777D2CB28C7AFEA008655BD /* UserDefault+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D777D2CA28C7AFEA008655BD /* UserDefault+Extension.swift */; };
 		D7B6C97C2858B2D40024F326 /* CheckRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B6C97B2858B2D40024F326 /* CheckRoomView.swift */; };
 /* End PBXBuildFile section */
 
@@ -278,8 +282,12 @@
 		CBBFF77B287AE491006A5964 /* DeveloperInfoViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperInfoViewCell.swift; sourceTree = "<group>"; };
 		D724AF5C287088310003F280 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		D724AF5E28708D830003F280 /* ImageRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRowView.swift; sourceTree = "<group>"; };
+		D739C36228C7B69D00161117 /* SettingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingProtocol.swift; sourceTree = "<group>"; };
+		D739C36428C7B75400161117 /* SettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAPI.swift; sourceTree = "<group>"; };
+		D739C36628C7B82500161117 /* NicknameDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameDTO.swift; sourceTree = "<group>"; };
 		D77224DE285DDAB7008B760B /* Notification+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extension.swift"; sourceTree = "<group>"; };
 		D777D2C828C7780E008655BD /* UrlLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlLiteral.swift; sourceTree = "<group>"; };
+		D777D2CA28C7AFEA008655BD /* UserDefault+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefault+Extension.swift"; sourceTree = "<group>"; };
 		D7B6C97B2858B2D40024F326 /* CheckRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckRoomView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -323,6 +331,7 @@
 				39CD582028C4C3E800496E91 /* DetailDoneAPI.swift */,
 				CB4C77E528C0D4EB007A1AD2 /* MainAPI.swift */,
 				B5F31C5128BFA64F00F61D0F /* LetterAPI.swift */,
+				D739C36428C7B75400161117 /* SettingAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -336,6 +345,7 @@
 				39CD581C28C4C03B00496E91 /* DetailDoneProtocol.swift */,
 				CB4C77E328C0D4C9007A1AD2 /* MainProtocol.swift */,
 				B5F31C5328BFA70100F61D0F /* LetterProtocol.swift */,
+				D739C36228C7B69D00161117 /* SettingProtocol.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -606,6 +616,7 @@
 				39C957CF2879521400A04A2B /* String+Extension.swift */,
 				39C957D12879523200A04A2B /* Date+Extension.swift */,
 				39018F4128C4708A00C78DBA /* UIButton+Extension.swift */,
+				D777D2CA28C7AFEA008655BD /* UserDefault+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -727,6 +738,7 @@
 				39C957E02879A3CF00A04A2B /* DailyMission.swift */,
 				397A241928BA532A00454E4F /* FriendList.swift */,
 				39CD581E28C4C19100496E91 /* Memory.swift */,
+				D739C36628C7B82500161117 /* NicknameDTO.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -997,6 +1009,7 @@
 				39C957DF2879A35300A04A2B /* RoomDTO.swift in Sources */,
 				39C95808287DB05C00A04A2B /* SettingEndPoint.swift in Sources */,
 				39C957F4287D9EB400A04A2B /* APIService.swift in Sources */,
+				D777D2CB28C7AFEA008655BD /* UserDefault+Extension.swift in Sources */,
 				B5F524CF28519AA000614FF7 /* AppDelegate.swift in Sources */,
 				B5E1F2B2285ECBDF006D880B /* SelectManittoViewController.swift in Sources */,
 				397A241828BA51B400454E4F /* DetailWaitProtocol.swift in Sources */,
@@ -1006,10 +1019,12 @@
 				B5F5251E2851A1C700614FF7 /* BaseTableViewCell.swift in Sources */,
 				39C957F6287D9ED000A04A2B /* NetworkRequest.swift in Sources */,
 				B5F5250C2851A07000614FF7 /* DetailIngViewController.swift in Sources */,
+				D739C36728C7B82500161117 /* NicknameDTO.swift in Sources */,
 				39C957FE287DAB6D00A04A2B /* DetailIngEndPoint.swift in Sources */,
 				B5F5251A2851A12600614FF7 /* BaseViewController.swift in Sources */,
 				CB4C77E428C0D4C9007A1AD2 /* MainProtocol.swift in Sources */,
 				CB85DE1F28A76F3400399109 /* SettingDeveloperInfoHeaderView.swift in Sources */,
+				D739C36528C7B75400161117 /* SettingAPI.swift in Sources */,
 				B5E1F2B0285EBB31006D880B /* OpenManittoPopupViewController.swift in Sources */,
 				B5F525062851A05500614FF7 /* CreateRoomViewController.swift in Sources */,
 				B5F524D128519AA000614FF7 /* SceneDelegate.swift in Sources */,
@@ -1020,6 +1035,7 @@
 				391B3003286198C200421F1D /* Size.swift in Sources */,
 				39C95800287DAC2900A04A2B /* DetailDoneEndPoint.swift in Sources */,
 				7E77DB0428BF9A6700E95D4B /* RoomProtocol.swift in Sources */,
+				D739C36328C7B69D00161117 /* SettingProtocol.swift in Sources */,
 				B5F525262851A26D00614FF7 /* NSObject+Extension.swift in Sources */,
 				7E0C5C362855B22700F698D1 /* CreateNickNameViewController.swift in Sources */,
 				CB674C1C285966020063A6B7 /* InputInvitedCodeView.swift in Sources */,

--- a/Manito/Manito/Global/Extension/UserDefault+Extension.swift
+++ b/Manito/Manito/Global/Extension/UserDefault+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  UserDefault+Extension.swift
+//  Manito
+//
+//  Created by 이성호 on 2022/09/07.
+//
+
+import Foundation
+
+extension UserDefaults {
+    var nickname: String? {
+        get {
+            let nickname = UserDefaults.standard.string(forKey: TextLiteral.userNickname)
+            return nickname
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: TextLiteral.userNickname)
+        }
+    }
+}

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -161,6 +161,11 @@ enum TextLiteral {
     // MARK: - InputDateView
     static let inputDateViewTitle: String = "진행 기간을 설정해 주세요"
     
+
+    // MARK: - UserDefault+Extension
+    static let userNickname: String = "UserNickname"
+
     // MARK: - ChangeNickNameViewController
     static let changeNickNameViewControllerTitle: String = "닉네임 변경하기"
+
 }

--- a/Manito/Manito/Network/API/SettingAPI.swift
+++ b/Manito/Manito/Network/API/SettingAPI.swift
@@ -1,0 +1,25 @@
+//
+//  SettingAPI.swift
+//  Manito
+//
+//  Created by 이성호 on 2022/09/07.
+//
+
+import Foundation
+
+struct SettingAPI: SettingProtocol {
+    
+    private let apiService: APIService
+    private let environment: APIEnvironment
+    
+    init(apiService: APIService, environment: APIEnvironment) {
+        self.apiService = apiService
+        self.environment = environment
+    }
+    
+    func putChangeNickname(body: NicknameDTO) async throws -> String? {
+        let request = SettingEndPoint.editUserInfo(nickNameDto: body)
+            .createRequest(environment: environment)
+        return try await apiService.request(request)
+    }
+}

--- a/Manito/Manito/Network/EndPoint/SettingEndPoint.swift
+++ b/Manito/Manito/Network/EndPoint/SettingEndPoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum SettingEndPoint: EndPointable {
-    case editUserInfo(nickName: String)
+    case editUserInfo(nickNameDto: NicknameDTO)
 
     var requestTimeOut: Float {
         return 20
@@ -23,8 +23,8 @@ enum SettingEndPoint: EndPointable {
 
     var requestBody: Data? {
         switch self {
-        case .editUserInfo(let nickName):
-            let body = ["nickName": nickName]
+        case .editUserInfo(let setting):
+            let body = setting
             return body.encode()
         }
     }
@@ -32,7 +32,19 @@ enum SettingEndPoint: EndPointable {
     func getURL(baseURL: String) -> String {
         switch self {
         case .editUserInfo(_):
-            return "\(baseURL)/api/user"
+            return "\(baseURL)/members/nickname"
         }
+    }
+    
+    func createRequest(environment: APIEnvironment) -> NetworkRequest {
+        var headers: [String: String] = [:]
+        headers["Content-Type"] = "application/json"
+        headers["authorization"] = "Bearer \(APIEnvironment.development.token)"
+        return NetworkRequest(url: getURL(baseURL: environment.baseUrl),
+                              headers: headers,
+                              reqBody: requestBody,
+                              reqTimeout: requestTimeOut,
+                              httpMethod: httpMethod
+        )
     }
 }

--- a/Manito/Manito/Network/Models/NicknameDTO.swift
+++ b/Manito/Manito/Network/Models/NicknameDTO.swift
@@ -1,0 +1,12 @@
+//
+//  Setting.swift
+//  Manito
+//
+//  Created by 이성호 on 2022/09/07.
+//
+
+import Foundation
+
+struct NicknameDTO: Codable {
+    let nickname: String?
+}

--- a/Manito/Manito/Network/Protocol/SettingProtocol.swift
+++ b/Manito/Manito/Network/Protocol/SettingProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  SettingProtocol.swift
+//  Manito
+//
+//  Created by 이성호 on 2022/09/07.
+//
+
+import Foundation
+
+protocol SettingProtocol {
+    func putChangeNickname(body: NicknameDTO) async throws -> String?
+}

--- a/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
+++ b/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 class CreateNickNameViewController: BaseViewController {
     
+    let settingService: SettingProtocol = SettingAPI(apiService: APIService(), environment: .development)
+    
     private var nickname: String = ""
     private let maxLength = 5
     
@@ -60,6 +62,24 @@ class CreateNickNameViewController: BaseViewController {
         setupNotificationCenter()
     }
     
+    // MARK: - API
+    func requestNickname(setting: NicknameDTO) {
+        Task {
+            do {
+                let data = try await settingService.putChangeNickname(body: setting)
+                if let nickname = data {
+                    print(nickname)
+                }
+            } catch NetworkError.serverError {
+                print("server Error")
+            } catch NetworkError.encodingError {
+                print("encoding Error")
+            } catch NetworkError.clientError(let message) {
+                print("client Error: \(message)")
+            }
+        }
+    }
+    
     override func render() {
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
@@ -92,6 +112,8 @@ class CreateNickNameViewController: BaseViewController {
     @objc private func didTapDoneButton() {
         if let text = roomsNameTextField.text, !text.isEmpty {
             nickname = text
+            UserDefaults.standard.nickname = nickname
+            requestNickname(setting: NicknameDTO(nickname: nickname))
             presentMainViewController()
         }
     }

--- a/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
+++ b/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
@@ -11,7 +11,9 @@ import SnapKit
 
 class ChangeNickNameViewController: BaseViewController {
     
-    private var nickname: String = "호야"
+    let settingService: SettingProtocol = SettingAPI(apiService: APIService(), environment: .development)
+    
+    private var nickname: String = UserDefaults.standard.nickname ?? "이성호"
     private var maxLength = 5
     
     // MARK: - Property
@@ -81,6 +83,8 @@ class ChangeNickNameViewController: BaseViewController {
     @objc private func didTapDoneButton() {
         if let text = nameTextField.text, !text.isEmpty {
             nickname = text
+            UserDefaults.standard.nickname = nickname
+            requestChangeNickname(nickname: NicknameDTO(nickname: nickname))
             navigationController?.popViewController(animated: true)
         }
     }
@@ -105,6 +109,21 @@ class ChangeNickNameViewController: BaseViewController {
         }
     }
     
+    // MARK: - API
+    func requestChangeNickname(nickname: NicknameDTO) {
+        Task {
+            do {
+                let _ = try await settingService.putChangeNickname(body: nickname)
+            } catch NetworkError.serverError {
+                print("server Error")
+            } catch NetworkError.encodingError {
+                print("encoding Error")
+            } catch NetworkError.clientError(let message) {
+                print("client Error: \(message)")
+            }
+        }
+    }
+
     // MARK: - Funtions
     
     private func setupDelegation() {

--- a/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
+++ b/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
@@ -13,7 +13,7 @@ class ChangeNickNameViewController: BaseViewController {
     
     let settingService: SettingProtocol = SettingAPI(apiService: APIService(), environment: .development)
     
-    private var nickname: String = UserDefaults.standard.nickname ?? "이성호"
+    private var nickname: String = UserDefaults.standard.nickname ?? ""
     private var maxLength = 5
     
     // MARK: - Property


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #201

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- 닉네임을 저장하는 userDefault를 편하게 쓰려고 익스텐션 했습니다.
- 닉네임 변경때 API 연결해서 보내는거 확인했습니다.

## 🟣 PR Point
- 애플 로그인 까지 머지되면 듀나의 유저디폴트 관리로 넘어가겠습니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

