### PR TITLE
[FIX] TextField 최대 카운트 이후로 생기는 문제 해결

### DIFF
--- a/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
+++ b/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
@@ -158,13 +158,26 @@ class CreateNickNameViewController: BaseViewController {
     }
     
     private func setCounter(count: Int) {
-        roomsTextLimit.text = "\(count)/\(maxLength)"
-        checkMaxLength(textField: roomsNameTextField, maxLength: maxLength)
+        if count <= maxLength {
+            roomsTextLimit.text = "\(count)/\(maxLength)"
+        } else {
+            roomsTextLimit.text = "\(maxLength)/\(maxLength)"
+        }
     }
     
     private func checkMaxLength(textField: UITextField, maxLength: Int) {
-        if (textField.text?.count ?? 0 > maxLength) {
-            textField.deleteBackward()
+        if let text = textField.text {
+            if text.count > maxLength {
+                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let fixedText = text[text.startIndex..<endIndex]
+                textField.text = fixedText + " "
+                
+                let when = DispatchTime.now() + 0.01
+                DispatchQueue.main.asyncAfter(deadline: when) {
+                    self.roomsNameTextField.text = String(fixedText)
+                    self.setCounter(count: textField.text?.count ?? 0)
+                }
+            }
         }
     }
     
@@ -184,6 +197,7 @@ extension CreateNickNameViewController : UITextFieldDelegate {
     
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)
+        checkMaxLength(textField: roomsNameTextField, maxLength: maxLength)
         
         let hasText = roomsNameTextField.hasText
         doneButton.isDisabled = !hasText

--- a/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
@@ -68,13 +68,26 @@ class InputNameView: UIView {
     // MARK: - Funtions
     
     private func setCounter(count: Int) {
-        roomsTextLimit.text = "\(count)/\(maxLength)"
-        checkMaxLength(textField: roomsNameTextField, maxLength: maxLength)
+        if count <= maxLength {
+            roomsTextLimit.text = "\(count)/\(maxLength)"
+        } else {
+            roomsTextLimit.text = "\(maxLength)/\(maxLength)"
+        }
     }
     
     private func checkMaxLength(textField: UITextField, maxLength: Int) {
-        if (textField.text?.count ?? 0 > maxLength) {
-            textField.deleteBackward()
+        if let text = textField.text {
+            if text.count > maxLength {
+                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let fixedText = text[text.startIndex..<endIndex]
+                textField.text = fixedText + " "
+                
+                let when = DispatchTime.now() + 0.01
+                DispatchQueue.main.asyncAfter(deadline: when) {
+                    self.roomsNameTextField.text = String(fixedText)
+                    self.setCounter(count: textField.text?.count ?? 0)
+                }
+            }
         }
     }
 }
@@ -82,6 +95,7 @@ class InputNameView: UIView {
 extension InputNameView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)
+        checkMaxLength(textField: roomsNameTextField, maxLength: maxLength)
         
         let hasText = roomsNameTextField.hasText
         changeNextButtonEnableStatus?(hasText)

--- a/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
+++ b/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
@@ -68,13 +68,26 @@ final class InputInvitedCodeView: UIView {
     // MARK: - func
     
     private func setCounter(count: Int) {
-        roomsTextLimit.text = "\(count)/\(maxLength)"
-        checkMaxLength(textField: roomCodeTextField, maxLength: maxLength)
+        if count <= maxLength {
+            roomsTextLimit.text = "\(count)/\(maxLength)"
+        } else {
+            roomsTextLimit.text = "\(maxLength)/\(maxLength)"
+        }
     }
     
     private func checkMaxLength(textField: UITextField, maxLength: Int) {
-        if (textField.text?.count ?? 0 > maxLength) {
-            textField.deleteBackward()
+        if let text = textField.text {
+            if text.count > maxLength {
+                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let fixedText = text[text.startIndex..<endIndex]
+                textField.text = fixedText + " "
+                
+                let when = DispatchTime.now() + 0.01
+                DispatchQueue.main.asyncAfter(deadline: when) {
+                    self.roomCodeTextField.text = String(fixedText)
+                    self.setCounter(count: textField.text?.count ?? 0)
+                }
+            }
         }
     }
 }
@@ -82,8 +95,10 @@ final class InputInvitedCodeView: UIView {
 extension InputInvitedCodeView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)
+        checkMaxLength(textField: roomCodeTextField, maxLength: maxLength)
         
-        let hasText = roomCodeTextField.text?.count == 6
+        guard let textCount = roomCodeTextField.text?.count else { return }
+        let hasText = textCount >= maxLength
         changeNextButtonEnableStatus?(hasText)
     }
 }

--- a/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
+++ b/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
@@ -136,12 +136,26 @@ class ChangeNickNameViewController: BaseViewController {
     }
     
     private func setCounter(count: Int) {
-        roomsTextLimit.text = "\(count)/\(maxLength)"
-        checkMaxLength(textField: nameTextField, maxLength: maxLength)
+        if count <= maxLength {
+            roomsTextLimit.text = "\(count)/\(maxLength)"
+        } else {
+            roomsTextLimit.text = "\(maxLength)/\(maxLength)"
+        }
     }
+    
     private func checkMaxLength(textField: UITextField, maxLength: Int) {
-        if (textField.text?.count ?? 0 > maxLength) {
-            textField.deleteBackward()
+        if let text = textField.text {
+            if text.count > maxLength {
+                let endIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let fixedText = text[text.startIndex..<endIndex]
+                textField.text = fixedText + " "
+                
+                let when = DispatchTime.now() + 0.01
+                DispatchQueue.main.asyncAfter(deadline: when) {
+                    self.nameTextField.text = String(fixedText)
+                    self.setCounter(count: textField.text?.count ?? 0)
+                }
+            }
         }
     }
     
@@ -167,6 +181,7 @@ extension ChangeNickNameViewController : UITextFieldDelegate {
     
     func textFieldDidChangeSelection(_ textField: UITextField) {
         setCounter(count: textField.text?.count ?? 0)
+        checkMaxLength(textField: nameTextField, maxLength: maxLength)
         
         let hasText = nameTextField.hasText
         doneButton.isDisabled = !hasText


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolve #232 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
TextField가 최대 카운트 이후에 타이핑을 하면 글자가 이상하게 먹히는 문제를 해결했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- Textfield가 다 차고 나면 글씨를 자동으로 지웁니다.
- 자동으로 지우는 코드가 조금 달그락 거려서 고것이 문제긴하지만 전과 같은 문제는 없습니다.
  ```swift
  DispatchQueue.main.asyncAfter(deadline: when) {
                    self.roomsNameTextField.text = String(fixedText)
                    self.setCounter(count: textField.text?.count ?? 0)
                }
  ```


## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

https://user-images.githubusercontent.com/55099365/189545261-35dc4424-db1c-4821-83c0-b33f4467e41d.mp4


