### PR TITLE
[CHORE] 버튼 높이가 달랐던거 수정

### DIFF
--- a/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
+++ b/Manito/Manito/Screens/CreateRoom/CreateRoomViewController.swift
@@ -105,7 +105,7 @@ class CreateRoomViewController: BaseViewController {
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(57)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(23)
             $0.height.equalTo(60)
         }
         


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #235

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- 방 생성하기 와 케릭터 선택뷰 사이의 버튼 위치가 달랐습니다.
- 방 생성하기에서 버튼의 위치가 safeArea에서부터가 아니라 바텀으로 부터 잡혀있었습니다. 


## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->


https://user-images.githubusercontent.com/59243274/189597482-40293f26-4607-470b-9c8e-5907ea582be2.mp4

