### PR TITLE
[FEAT] 마니또 공개버튼 종료일 9시이후 활성화되게 추가

### DIFF
--- a/Manito/Manito/Global/Extension/Date+Extension.swift
+++ b/Manito/Manito/Global/Extension/Date+Extension.swift
@@ -23,11 +23,7 @@ extension Date {
     func isToday() -> Bool {
         let now = Date()
         let distance = self.distance(to: now)
-        if distance > 0 && distance < 86400 {
-            return true
-        } else {
-            return false
-        }
+        return distance > 0 && distance < 86400
     }
     
     func isOverOpenTime() -> Bool {
@@ -35,11 +31,7 @@ extension Date {
         let nineHoursTimeInterval: TimeInterval = 32400
         let dateAddNineHours = self + nineHoursTimeInterval
         let distance = dateAddNineHours.distance(to: now)
-        if distance > 0 && distance < 54000 {
-            return true
-        } else {
-            return false
-        }
+        return distance > 0 && distance < 54000
     }
     
     func isOpenManitto() -> Bool {

--- a/Manito/Manito/Global/Extension/Date+Extension.swift
+++ b/Manito/Manito/Global/Extension/Date+Extension.swift
@@ -20,13 +20,13 @@ extension Date {
         return formatter.string(from: self)
     }
     
-    func isToday() -> Bool {
+    var isToday: Bool {
         let now = Date()
         let distance = self.distance(to: now)
         return distance > 0 && distance < 86400
     }
     
-    func isOverOpenTime() -> Bool {
+    var isOverOpenTime: Bool {
         let now = Date()
         let nineHoursTimeInterval: TimeInterval = 32400
         let dateAddNineHours = self + nineHoursTimeInterval
@@ -34,7 +34,7 @@ extension Date {
         return distance > 0 && distance < 54000
     }
     
-    func isOpenManitto() -> Bool {
-        return self.isToday() && self.isOverOpenTime()
+    var isOpenManitto: Bool {
+        return self.isToday && self.isOverOpenTime
     }
 }

--- a/Manito/Manito/Global/Extension/Date+Extension.swift
+++ b/Manito/Manito/Global/Extension/Date+Extension.swift
@@ -35,10 +35,6 @@ extension Date {
     }
     
     func isOpenManitto() -> Bool {
-        if self.isToday() && self.isOverOpenTime() {
-            return true
-        } else {
-            return false
-        }
+        return self.isToday() && self.isOverOpenTime()
     }
 }

--- a/Manito/Manito/Global/Extension/Date+Extension.swift
+++ b/Manito/Manito/Global/Extension/Date+Extension.swift
@@ -19,4 +19,34 @@ extension Date {
         formatter.dateFormat = "yyyy.MM.dd"
         return formatter.string(from: self)
     }
+    
+    func isToday() -> Bool {
+        let now = Date()
+        let distance = self.distance(to: now)
+        if distance > 0 && distance < 86400 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func isOverOpenTime() -> Bool {
+        let now = Date()
+        let nineHoursTimeInterval: TimeInterval = 32400
+        let dateAddNineHours = self + nineHoursTimeInterval
+        let distance = dateAddNineHours.distance(to: now)
+        if distance > 0 && distance < 54000 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func isOpenManitto() -> Bool {
+        if self.isToday() && self.isOverOpenTime() {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/Manito/Manito/Global/Extension/String+Extension.swift
+++ b/Manito/Manito/Global/Extension/String+Extension.swift
@@ -18,4 +18,13 @@ extension String {
         let startIdx: String.Index = self.index(self.startIndex, offsetBy: 2)
         return String(self[startIdx...])
     }
+    
+    func stringToDateYYYY() -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.timeZone = TimeZone(abbreviation: "KST")
+        formatter.locale = Locale(identifier: "ko_KR")
+        let date = formatter.date(from: self)
+        return date
+    }
 }

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -225,7 +225,7 @@ class DetailIngViewController: BaseViewController {
         guard let endDateToString = roomInformation?.endDate else { return }
         guard let endDate = endDateToString.stringToDateYYYY() else { return }
 
-        manitoOpenButton.isDisabled = !endDate.isOpenManitto()
+        manitoOpenButton.isDisabled = !endDate.isOpenManitto
     }
     
     // MARK: - DetailStarting API

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -225,11 +225,7 @@ class DetailIngViewController: BaseViewController {
         guard let endDateToString = roomInformation?.endDate else { return }
         guard let endDate = endDateToString.stringToDateYYYY() else { return }
 
-        if endDate.isOpenManitto() {
-            manitoOpenButton.isDisabled = false
-        } else {
-            manitoOpenButton.isDisabled = true
-        }
+        manitoOpenButton.isDisabled = !endDate.isOpenManitto()
     }
     
     // MARK: - DetailStarting API

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -56,10 +56,9 @@ class DetailIngViewController: BaseViewController {
         return imageView
     }()
     
-    private let manitoOpenButton: UIButton = {
+    private let manitoOpenButton: MainButton = {
         let button = MainButton()
         button.title = TextLiteral.detailIngViewControllerManitoOpenButton
-        button.hasShadow = true
         return button
     }()
     
@@ -75,6 +74,7 @@ class DetailIngViewController: BaseViewController {
             requestDoneRoomInfo()
         case .PROCESSING:
             requestRoomInfo()
+            setupOpenManittoButton()
         case .none: break
         }
     }
@@ -219,6 +219,17 @@ class DetailIngViewController: BaseViewController {
             self?.navigationController?.pushViewController(OpenManittoViewController(), animated: true)
         }
         self.manitoOpenButton.addAction(action, for: .touchUpInside)
+    }
+    
+    private func setupOpenManittoButton() {
+        guard let endDate = roomInformation?.endDate else { return }
+        guard let endDateToDate = endDate.stringToDateYYYY() else { return }
+
+        if endDateToDate.isOpenManitto() {
+            manitoOpenButton.isDisabled = false
+        } else {
+            manitoOpenButton.isDisabled = true
+        }
     }
     
     // MARK: - DetailStarting API

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -222,10 +222,10 @@ class DetailIngViewController: BaseViewController {
     }
     
     private func setupOpenManittoButton() {
-        guard let endDate = roomInformation?.endDate else { return }
-        guard let endDateToDate = endDate.stringToDateYYYY() else { return }
+        guard let endDateToString = roomInformation?.endDate else { return }
+        guard let endDate = endDateToString.stringToDateYYYY() else { return }
 
-        if endDateToDate.isOpenManitto() {
+        if endDate.isOpenManitto() {
             manitoOpenButton.isDisabled = false
         } else {
             manitoOpenButton.isDisabled = true


### PR DESCRIPTION
## 🟣 관련 이슈
- close #228 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟣 구현/변경 사항 및 이유
- 마니또 공개버튼이 당일 && 당일 09:00 이후에 버튼이 활성화 되게 변경했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point
- Extension에 추가했습니당
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항
<img width="356" alt="image" src="https://user-images.githubusercontent.com/78677571/189614198-dfe78068-3119-4b45-b183-46d18f1c8feb.png">

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

