### PR TITLE
[FEAT] Header Code에 있는 값들을 return할 수 있도록 request 구현

### DIFF
--- a/Manito/Manito/Network/API/LetterAPI.swift
+++ b/Manito/Manito/Network/API/LetterAPI.swift
@@ -32,7 +32,7 @@ struct LetterAPI: LetterProtocol {
     }
     
     @discardableResult
-    func dispatchLetter(roomId: String, image: Data? = nil, letter: LetterDTO) async throws -> Letter? {
+    func dispatchLetter(roomId: String, image: Data? = nil, letter: LetterDTO) async throws -> Int {
         let request = LetterEndPoint
             .dispatchLetter(roomId: roomId, image: image, letter: letter)
             .createRequest(environment: environment)

--- a/Manito/Manito/Network/API/RoomAPI.swift
+++ b/Manito/Manito/Network/API/RoomAPI.swift
@@ -14,11 +14,11 @@ struct RoomAPI: RoomProtocol {
         self.apiService = apiService
     }
     
-    func postCreateRoom(body: CreateRoomDTO) async throws -> String? {
+    func postCreateRoom(body: CreateRoomDTO) async throws -> Int? {
         let request = RoomEndPoint
             .dispatchCreateRoom(roomInfo: body)
             .createRequest()
-        return try await apiService.request(request)
+        return try await apiService.requestCreateRoom(request)
     }
     
     func getVerification(body: String) async throws -> VerificationCode? {

--- a/Manito/Manito/Network/Protocol/LetterProtocol.swift
+++ b/Manito/Manito/Network/Protocol/LetterProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 protocol LetterProtocol {
     func fetchSendLetter(roomId: String) async throws -> Letter?
     func fetchReceiveLetter(roomId: String) async throws -> Letter?
-    func dispatchLetter(roomId: String, image: Data?, letter: LetterDTO) async throws -> Letter?
+    func dispatchLetter(roomId: String, image: Data?, letter: LetterDTO) async throws -> Int
 }

--- a/Manito/Manito/Network/Protocol/RoomProtocol.swift
+++ b/Manito/Manito/Network/Protocol/RoomProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol RoomProtocol {
-    func postCreateRoom(body: CreateRoomDTO) async throws -> String?
+    func postCreateRoom(body: CreateRoomDTO) async throws -> Int?
     func getVerification(body: String) async throws -> VerificationCode?
     func dispatchJoinRoom(roodId: String, dto: MemberDTO) async throws -> String?
 }

--- a/Manito/Manito/Network/Service/APIService.swift
+++ b/Manito/Manito/Network/Service/APIService.swift
@@ -26,14 +26,12 @@ final class APIService: Requestable {
         }
     }
     
-    func request<T: Decodable>(_ request: NetworkRequest) async throws -> (T?, Int) {
-        let (data, httpResponse) = try await requestDataToUrl(request)
+    func request(_ request: NetworkRequest) async throws -> Int {
+        let (_, httpResponse) = try await requestDataToUrl(request)
         
         switch httpResponse.statusCode {
         case (200..<300):
-            let decoder = JSONDecoder()
-            let baseModelData: T? = try decoder.decode(T.self, from: data)
-            return (baseModelData, httpResponse.statusCode)
+            return httpResponse.statusCode
         case (300..<500):
             throw NetworkError.clientError(message: httpResponse.statusCode.description)
         default:

--- a/Manito/Manito/Network/Service/APIService.swift
+++ b/Manito/Manito/Network/Service/APIService.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class APIService: Requestable {
+    
     var requestTimeOut: Float = 30
 
     func request<T: Decodable>(_ request: NetworkRequest) async throws -> T? {
@@ -31,5 +32,57 @@ final class APIService: Requestable {
         default:
             throw NetworkError.serverError
         }
+    }
+    
+    func request<T: Decodable>(_ request: NetworkRequest) async throws -> (T?, Int) {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForRequest = TimeInterval(request.requestTimeOut ?? requestTimeOut)
+        guard let encodedUrl = request.url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+            let url = URL(string: encodedUrl) else {
+            throw NetworkError.encodingError
+        }
+        print("encodedUrl = \(encodedUrl)")
+
+        let (data, response) = try await URLSession.shared.data(for: request.buildURLRequest(with: url))
+        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.serverError }
+        switch httpResponse.statusCode {
+        case (200..<300):
+            let decoder = JSONDecoder()
+            let baseModelData: T? = try decoder.decode(T.self, from: data)
+            return (baseModelData, httpResponse.statusCode)
+        case (300..<500):
+            throw NetworkError.clientError(message: "\(httpResponse.statusCode)")
+        default:
+            throw NetworkError.serverError
+        }
+    }
+    
+    func requestCreateRoom(_ request: NetworkRequest) async throws -> Int? {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForRequest = TimeInterval(request.requestTimeOut ?? requestTimeOut)
+        guard let encodedUrl = request.url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+            let url = URL(string: encodedUrl) else {
+            throw NetworkError.encodingError
+        }
+        print("encodedUrl = \(encodedUrl)")
+
+        let (_, response) = try await URLSession.shared.data(for: request.buildURLRequest(with: url))
+        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.serverError }
+        switch httpResponse.statusCode {
+        case (200..<300):
+            let responseUrl = httpResponse.value(forHTTPHeaderField: "Location")
+            return responseUrl?.roomId
+        case (300..<500):
+            throw NetworkError.clientError(message: "\(httpResponse.statusCode)")
+        default:
+            throw NetworkError.serverError
+        }
+    }
+}
+
+private extension String {
+    var roomId: Int? {
+        guard let id = self.split(separator: "/").last.map({ Int($0) }) else { return nil }
+        return id
     }
 }

--- a/Manito/Manito/Network/Service/APIService.swift
+++ b/Manito/Manito/Network/Service/APIService.swift
@@ -12,29 +12,54 @@ final class APIService: Requestable {
     var requestTimeOut: Float = 30
 
     func request<T: Decodable>(_ request: NetworkRequest) async throws -> T? {
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.timeoutIntervalForRequest = TimeInterval(request.requestTimeOut ?? requestTimeOut)
-        guard let encodedUrl = request.url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-            let url = URL(string: encodedUrl) else {
-            throw NetworkError.encodingError
-        }
-        print("encodedUrl = \(encodedUrl)")
-
-        let (data, response) = try await URLSession.shared.data(for: request.buildURLRequest(with: url))
-        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.serverError }
+        let (data, httpResponse) = try await requestDataToUrl(request)
+        
         switch httpResponse.statusCode {
         case (200..<300):
             let decoder = JSONDecoder()
             let baseModelData: T? = try decoder.decode(T.self, from: data)
             return baseModelData
         case (300..<500):
-            throw NetworkError.clientError(message: "\(httpResponse.statusCode)")
+            throw NetworkError.clientError(message: httpResponse.statusCode.description)
         default:
             throw NetworkError.serverError
         }
     }
     
     func request<T: Decodable>(_ request: NetworkRequest) async throws -> (T?, Int) {
+        let (data, httpResponse) = try await requestDataToUrl(request)
+        
+        switch httpResponse.statusCode {
+        case (200..<300):
+            let decoder = JSONDecoder()
+            let baseModelData: T? = try decoder.decode(T.self, from: data)
+            return (baseModelData, httpResponse.statusCode)
+        case (300..<500):
+            throw NetworkError.clientError(message: httpResponse.statusCode.description)
+        default:
+            throw NetworkError.serverError
+        }
+    }
+    
+    func requestCreateRoom(_ request: NetworkRequest) async throws -> Int? {
+        let (_, httpResponse) = try await requestDataToUrl(request)
+        
+        switch httpResponse.statusCode {
+        case (200..<300):
+            let responseUrl = httpResponse.value(forHTTPHeaderField: "Location")
+            return responseUrl?.roomId
+        case (300..<500):
+            throw NetworkError.clientError(message: httpResponse.statusCode.description)
+        default:
+            throw NetworkError.serverError
+        }
+    }
+}
+
+extension APIService {
+    typealias UrlResponse = (Data, HTTPURLResponse)
+    
+    private func requestDataToUrl(_ request: NetworkRequest) async throws -> UrlResponse {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = TimeInterval(request.requestTimeOut ?? requestTimeOut)
         guard let encodedUrl = request.url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
@@ -45,38 +70,8 @@ final class APIService: Requestable {
 
         let (data, response) = try await URLSession.shared.data(for: request.buildURLRequest(with: url))
         guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.serverError }
-        switch httpResponse.statusCode {
-        case (200..<300):
-            let decoder = JSONDecoder()
-            let baseModelData: T? = try decoder.decode(T.self, from: data)
-            return (baseModelData, httpResponse.statusCode)
-        case (300..<500):
-            throw NetworkError.clientError(message: "\(httpResponse.statusCode)")
-        default:
-            throw NetworkError.serverError
-        }
-    }
-    
-    func requestCreateRoom(_ request: NetworkRequest) async throws -> Int? {
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.timeoutIntervalForRequest = TimeInterval(request.requestTimeOut ?? requestTimeOut)
-        guard let encodedUrl = request.url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-            let url = URL(string: encodedUrl) else {
-            throw NetworkError.encodingError
-        }
-        print("encodedUrl = \(encodedUrl)")
-
-        let (_, response) = try await URLSession.shared.data(for: request.buildURLRequest(with: url))
-        guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.serverError }
-        switch httpResponse.statusCode {
-        case (200..<300):
-            let responseUrl = httpResponse.value(forHTTPHeaderField: "Location")
-            return responseUrl?.roomId
-        case (300..<500):
-            throw NetworkError.clientError(message: "\(httpResponse.statusCode)")
-        default:
-            throw NetworkError.serverError
-        }
+        
+        return (data, httpResponse)
     }
 }
 

--- a/Manito/Manito/Network/Service/Requestable.swift
+++ b/Manito/Manito/Network/Service/Requestable.swift
@@ -11,6 +11,6 @@ protocol Requestable {
     var requestTimeOut: Float { get }
     
     func request<T: Decodable>(_ request: NetworkRequest) async throws -> T?
-    func request<T: Decodable>(_ request: NetworkRequest) async throws -> (T?, Int)
+    func request(_ request: NetworkRequest) async throws -> Int
     func requestCreateRoom(_ request: NetworkRequest) async throws -> Int?
 }

--- a/Manito/Manito/Network/Service/Requestable.swift
+++ b/Manito/Manito/Network/Service/Requestable.swift
@@ -11,4 +11,6 @@ protocol Requestable {
     var requestTimeOut: Float { get }
     
     func request<T: Decodable>(_ request: NetworkRequest) async throws -> T?
+    func request<T: Decodable>(_ request: NetworkRequest) async throws -> (T?, Int)
+    func requestCreateRoom(_ request: NetworkRequest) async throws -> Int?
 }

--- a/Manito/Manito/Screens/ChooseCharacter/ChooseCharacterViewController.swift
+++ b/Manito/Manito/Screens/ChooseCharacter/ChooseCharacterViewController.swift
@@ -168,7 +168,17 @@ class ChooseCharacterViewController: BaseViewController {
     func requestCreateRoom(room: CreateRoomDTO) {
         Task {
             do {
-                let _ = try await roomService.postCreateRoom(body: room)
+                guard
+                    let roomId = try await roomService.postCreateRoom(body: room),
+                    let navigationController = self.presentingViewController as? UINavigationController
+                else { return }
+                let viewController = DetailWaitViewController(index: roomId)
+                navigationController.popViewController(animated: true)
+                navigationController.pushViewController(viewController, animated: false)
+                
+                self.dismiss(animated: true) {
+                    NotificationCenter.default.post(name: .createRoomInvitedCode, object: nil)
+                }
             } catch NetworkError.serverError {
                 print("server Error")
             } catch NetworkError.encodingError {
@@ -213,14 +223,6 @@ class ChooseCharacterViewController: BaseViewController {
                                                                 startDate: roomInfo.startDate,
                                                                 endDate: roomInfo.endDate) ,
                                                   member: MemberDTO(colorIdx: colorIdx)))
-            guard let navigationController = self.presentingViewController as? UINavigationController else { return }
-            let viewController = DetailWaitViewController(index: 51) //FIXME
-            navigationController.popViewController(animated: true)
-            navigationController.pushViewController(viewController, animated: false)
-            
-            self.dismiss(animated: true) {
-                NotificationCenter.default.post(name: .createRoomInvitedCode, object: nil)
-            }
         case .enterRoom:
             requestJoinRoom()
         }

--- a/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
@@ -182,11 +182,7 @@ final class CreateLetterViewController: BaseViewController {
             guard let roomId = self?.roomId else { return }
 
             self?.dispatchLetter(roomId: roomId)
-            self?.dismiss(animated: true, completion: {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
-                    self?.createLetter?()
-                })
-            })
+            self?.dismiss(animated: true)
         }
         
         cancelButton.addAction(cancelAction, for: .touchUpInside)
@@ -225,17 +221,29 @@ final class CreateLetterViewController: BaseViewController {
                     guard let jpegData = image.jpegData(compressionQuality: 0.3) else { return }
                     let dto = LetterDTO(manitteeId: manitteeId, messageContent: content)
                     
-                    try await letterSevice.dispatchLetter(roomId: roomId, image: jpegData, letter: dto)
+                    let status = try await letterSevice.dispatchLetter(roomId: roomId, image: jpegData, letter: dto)
+                    
+                    if status == 201 {
+                        self.createLetter?()
+                    }
                 } else if let content = letterTextView.letterTextView.text {
                     let dto = LetterDTO(manitteeId: manitteeId, messageContent: content)
                     
-                    try await letterSevice.dispatchLetter(roomId: roomId, letter: dto)
+                    let status = try await letterSevice.dispatchLetter(roomId: roomId, letter: dto)
+                    
+                    if status == 201 {
+                        self.createLetter?()
+                    }
                 } else if let image = letterPhotoView.importPhotosButton.imageView?.image,
                           image != ImageLiterals.btnCamera {
                     guard let jpegData = image.jpegData(compressionQuality: 0.3) else { return }
                     let dto = LetterDTO(manitteeId: manitteeId)
                     
-                    try await letterSevice.dispatchLetter(roomId: roomId, image: jpegData, letter: dto)
+                    let status = try await letterSevice.dispatchLetter(roomId: roomId, image: jpegData, letter: dto)
+                    
+                    if status == 201 {
+                        self.createLetter?()
+                    }
                 }
                 
             } catch NetworkError.serverError {


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #245 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
Header Code에 있는 값들을 return할 수 있도록 request를 수정해서 구현했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- StatusCode를 return하는 `request`
- 쪽지 보내기 부분에서 해당 방식을 사용했습니다.
```swift
    func request(_ request: NetworkRequest) async throws -> Int {
        let (_, httpResponse) = try await requestDataToUrl(request)

        switch httpResponse.statusCode {
        case (200..<300):
            return httpResponse.statusCode
        case (300..<500):
            throw NetworkError.clientError(message: httpResponse.statusCode.description)
        default:
            throw NetworkError.serverError
        }
}
```

<br/>

- Location를 return하는 `request`
- 방 생성 부분에서 해당 방식을 사용했습니다.
```swift 
func requestCreateRoom(_ request: NetworkRequest) async throws -> Int? {
        let (_, httpResponse) = try await requestDataToUrl(request)

        switch httpResponse.statusCode {
        case (200..<300):
            let responseUrl = httpResponse.value(forHTTPHeaderField: "Location")
            return responseUrl?.roomId
        case (300..<500):
            throw NetworkError.clientError(message: httpResponse.statusCode.description)
        default:
            throw NetworkError.serverError
        }
}
```


## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

