### PR TITLE
[CHORE] 최소 시작 인원 5명 -> 4명 수정

### DIFF
--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -28,7 +28,7 @@ enum TextLiteral {
     static let maxMessage: String = "최대 7일까지 선택가능해요"
     static let destructive: String = "변경 사항 폐기"
     static let per: String = "인"
-    static let minMember: String = "5인"
+    static let minMember: String = "4인"
     static let maxMember: String = "15인"
     static let x: String = "X"
     static let createRoom: String = "방 생성하기"

--- a/Manito/Manito/Screens/CreateRoom/Component/InputPersonView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputPersonView.swift
@@ -39,7 +39,7 @@ class InputPersonView: UIView {
     lazy var personSlider: UISlider = {
         let slider = UISlider()
         slider.value = 1
-        slider.minimumValue = 5
+        slider.minimumValue = 4
         slider.maximumValue = 15
         slider.tintColor = .mainRed
         slider.setThumbImage(ImageLiterals.imageSliderThumb, for: .normal)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -106,7 +106,7 @@ class DetailEditViewController: BaseViewController {
     }()
     private lazy var memberSlider: UISlider = {
         let slider = UISlider()
-        slider.minimumValue = 5
+        slider.minimumValue = 4
         slider.maximumValue = 15
         slider.maximumTrackTintColor = .darkGrey003
         slider.minimumTrackTintColor = .red001


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
1차 배포후 꽤나 많이 나온 피드백중 하나였던 최소 인원 문제가 있었습니다. 저희가 처음 기획했을 땐 애플아카데미를 대상으로 하다보니 최소 5명은 있겠다 ! 란 생각에 최소인원을 5명으로 설정했습니다. 하지만 앱이 배포되고 외부에서도 많이 사용하게 되었는데, 4명이었으면 애니또를 할 수 있었는데 5명이라 못했다는 피드백이 꽤 있었습니다. 이에대해 내부적으로 얘기했을때도 "5명일 이유는 없는 것 같다"란 결론이 나왔습니다. 그래서 3명이선 마니또를 할 수 없으니 진짜 마지노선인 4명으로 수정하기로 지난 회의때 얘기가 되었습니다. 인원 수정을 6차 스프린트로 잡았고 이에 대해 작업한 PR입니다. 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
최소 인원을 5명에서 4명으로 수정했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/329-minimum-member 브랜치로 오셔서 실행시키시면 됩니다
방 생성 View와 대기중인 방의 정보를 변경하는 View에서 Slider를 움직여 보시면 됩니다 !
애플로그인이 이제 시뮬레이터에서도 되더라구요. 아직까지 팀 세팅이 안됐지만 테스트하기엔 문제 없어 보입니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

https://user-images.githubusercontent.com/78677571/199723529-ca2954f7-0cd1-4d7b-977d-fdfe95310b70.mp4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이 작업하면서 들었던 생각이 단지 최소인원이 5명에서 4명으로 줄어드는건데 TextLiteral에서도 변경해야하고, 각각의 뷰를 찾아가서 slider의 최소값을 수정해줘야하는 번거로움이 있었습니다. 그래서 
### ValueLiteral 같이 수치들을 모아두는 곳이 있으면 어떨까.. 싶은 생각이 들었습니다. 

거기에 들어갈 수 있는 값들로는 마니또 최소인원, 최대인원, 마니또 기간정도가 있을 것 같네요.. 더 있을 수도 있지만 생각이 나질 않네요

현재 클라쪽에서만 4명으로 수정한다고 바로 적용되는 건 아니더라구요... 서버 선생님들께서도 최소 인원을 5명으로 설정해두셔서 4명으로 수정하는 작업이 필요합니다. 현재 이에 대해선 슬랙에 메시지를 보내둔 상태입니다.
<img width="520" alt="image" src="https://user-images.githubusercontent.com/78677571/199725370-61cbf679-cec6-4a7e-8013-f90198549d83.png">


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #329


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->