### PR TITLE
[FIX] LetterView Guide View 사라지지 않는 문제를 해결했습니다.

### DIFF
--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -199,6 +199,10 @@ final class LetterViewController: BaseViewController {
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        guideBoxImageView.isHidden = true
+    }
+    
     // MARK: - func
     
     private func setupLargeTitle() {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

https://user-images.githubusercontent.com/78677571/199732754-7fd065d4-1766-4097-a346-c1c0f2be8e65.mp4

위의 영상에서 보면 쪽지함 뷰에서 가이드 버튼을 누르면 내용이 잘 표시됩니다. 뒤로가기를 해도 잘 사라지고, 한번 더 눌러도 잘 사라지고, 세그먼트를 이동해도 잘 사라집니다. 하지만 사라지지 않는 한 방법이 있었습니다.
왼쪽으로 쓸어서 dismiss를 하게되면 해당 뷰가 사라지지 않고 둥둥 떠있는 현상이 발생했습니다. 어딜가나 계속 떠있고, 앱을 껐다 켜는 것 말고는 사라지게 하는 방법이 없었습니다. 
이 문제를 해결하기 위한 PR입니다 ^_______^

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
해당 이미지 view를 viewController의 life cycle중 하나인 `viewWillDisappear` 부분에서 `isHidden` 처리시켜 주었습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/331-letter-info-bugfix 브랜치로 오셔서 실행 시키시고, 진행중이나 완료방의 쪽지함으로 가시면 됩니다.
이후 오른쪽 위의 가이드 버튼을 누르고 뒤로갔을 때 잘 사라지는지 확인 해주시면 됩니다.

viewWillDisappear 부분을 주석처리했을때, 가이드 뷰가 떠있는 상태로 왼쪽으로 쓸어서 뒤로가기를 한다면 해당 버그가 발생될 것이고, 주석을 해제하면 가이드 뷰가 잘 사라질겁니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
## 해결 화면
https://user-images.githubusercontent.com/78677571/199733941-08923a8b-7268-44e9-af6a-a6e0b88c38fd.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
`viewWillDisappear` 부분과 `viewDidDisappear` 부분을 고민했는데, 

|viewWillDisappear (현재 PR에서 구현한 방식) |viewDidDisappear|
|---|---|
|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-03 at 22 38 00](https://user-images.githubusercontent.com/78677571/199735619-6652c004-df9e-4143-9351-2d00fc56f899.gif)|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-03 at 22 39 44](https://user-images.githubusercontent.com/78677571/199736063-fb98fc2b-f7f1-4df8-9390-3d11679f50cf.gif)|

두 차이를 보면, 사라지기 시작했을 때 hidden 처리 되는 것과, 완전 없어졌을 때 hidden 처리되는 방식의 차이가 있습니다.
두 상태를 고려했을 때 사라지기 시작했을 때 바로 hidden 처리되는 것이 맞는 것 같다 생각이 들었고, 그렇게 구현해두었습니다 !

혹시 다른 의견이 있다면 알려주세요 ! ^________^

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #331 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->