### PR TITLE
[FIX] 텍스트 필드 달그락 거리는 버그 해결

### DIFF
--- a/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
+++ b/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
@@ -183,7 +183,6 @@ class CreateNickNameViewController: BaseViewController {
                 
                 DispatchQueue.main.async {
                     self.roomsNameTextField.text = String(fixedText)
-                    self.setCounter(count: textField.text?.count ?? 0)
                 }
             }
         }

--- a/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
+++ b/Manito/Manito/Screens/CreateNickName/CreateNickNameViewController.swift
@@ -181,8 +181,7 @@ class CreateNickNameViewController: BaseViewController {
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
                 
-                let when = DispatchTime.now() + 0.01
-                DispatchQueue.main.asyncAfter(deadline: when) {
+                DispatchQueue.main.async {
                     self.roomsNameTextField.text = String(fixedText)
                     self.setCounter(count: textField.text?.count ?? 0)
                 }

--- a/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
@@ -84,8 +84,7 @@ class InputNameView: UIView {
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
                 
-                let when = DispatchTime.now() + 0.01
-                DispatchQueue.main.asyncAfter(deadline: when) {
+                DispatchQueue.main.async {
                     self.roomsNameTextField.text = String(fixedText)
                     self.setCounter(count: textField.text?.count ?? 0)
                 }

--- a/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
+++ b/Manito/Manito/Screens/CreateRoom/Component/InputNameView.swift
@@ -86,7 +86,6 @@ class InputNameView: UIView {
                 
                 DispatchQueue.main.async {
                     self.roomsNameTextField.text = String(fixedText)
-                    self.setCounter(count: textField.text?.count ?? 0)
                 }
             }
         }

--- a/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
+++ b/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
@@ -84,8 +84,7 @@ final class InputInvitedCodeView: UIView {
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
                 
-                let when = DispatchTime.now() + 0.01
-                DispatchQueue.main.asyncAfter(deadline: when) {
+                DispatchQueue.main.async {
                     self.roomCodeTextField.text = String(fixedText)
                     self.setCounter(count: textField.text?.count ?? 0)
                 }

--- a/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
+++ b/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
@@ -86,7 +86,6 @@ final class InputInvitedCodeView: UIView {
                 
                 DispatchQueue.main.async {
                     self.roomCodeTextField.text = String(fixedText)
-                    self.setCounter(count: textField.text?.count ?? 0)
                 }
             }
         }

--- a/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
+++ b/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
@@ -171,7 +171,6 @@ class ChangeNickNameViewController: BaseViewController {
                 
                 DispatchQueue.main.async {
                     self.nameTextField.text = String(fixedText)
-                    self.setCounter(count: textField.text?.count ?? 0)
                 }
             }
         }

--- a/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
+++ b/Manito/Manito/Screens/Setting/ChangeNickNameViewController.swift
@@ -169,8 +169,7 @@ class ChangeNickNameViewController: BaseViewController {
                 let fixedText = text[text.startIndex..<endIndex]
                 textField.text = fixedText + " "
                 
-                let when = DispatchTime.now() + 0.01
-                DispatchQueue.main.asyncAfter(deadline: when) {
+                DispatchQueue.main.async {
                     self.nameTextField.text = String(fixedText)
                     self.setCounter(count: textField.text?.count ?? 0)
                 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재 텍스트필드에 텍스트를 입력하면 달그락달그락 거리는 문제가 있습니다. 그 버그를 해결하는 PR입니다.

### 버그가 생긴 원인 
현재 0.01초 이후에 실행되도록 보장하는 코드가 있습니다. 
이코드 때문에 달그락 거리는 버그가 있는 모습으로 구현되었는데 0.01초 이후에 실행되도록 보장하지 않아도 잘 실행되기 때문에 그 부분의 코드를 삭제했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 텍스트 필드가 있는 코드들은 다 수정했습니다.
- 버그 해결

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 텍스트 필드가 현재 로그인 후에는 방생성, 방참여, 닉네임 수정 시 있습니다. 그 쪽으로 와서 최대글자를 입력해보시면 됩니다


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://user-images.githubusercontent.com/59243274/200124025-96d9ef07-1e0e-4b9a-8c45-cfcd5ce88130.mp4" width="350">






## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 날먹 PR입니다. 화이팅!


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #324 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
