### PR TITLE
[FEAT] 푸시알림을 눌렀을 때 해당 방의 쪽지뷰로 이동 기능 구현

### DIFF
--- a/Manito/Manito/Global/Supports/AppDelegate.swift
+++ b/Manito/Manito/Global/Supports/AppDelegate.swift
@@ -101,7 +101,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler([.badge, .sound])
       }
       
-      func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
+                as? SceneDelegate else { return }
+        let userInfo = response.notification.request.content.userInfo
+        if let roomId = userInfo["roomId"] as? String {
+            guard let roomId = Int(roomId) else { return }
+            sceneDelegate.changeRootViewWithMessageView(roomId: roomId)
+        }
+        
         completionHandler()
-      }
+    }
 }

--- a/Manito/Manito/Global/Supports/AppDelegate.swift
+++ b/Manito/Manito/Global/Supports/AppDelegate.swift
@@ -108,6 +108,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if let roomId = userInfo["roomId"] as? String {
             guard let roomId = Int(roomId) else { return }
             sceneDelegate.changeRootViewWithLetterView(roomId: roomId)
+        } else {
+            sceneDelegate.showRoomIdErrorAlert()
         }
         
         completionHandler()

--- a/Manito/Manito/Global/Supports/AppDelegate.swift
+++ b/Manito/Manito/Global/Supports/AppDelegate.swift
@@ -107,7 +107,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
         if let roomId = userInfo["roomId"] as? String {
             guard let roomId = Int(roomId) else { return }
-            sceneDelegate.changeRootViewWithMessageView(roomId: roomId)
+            sceneDelegate.changeRootViewWithLetterView(roomId: roomId)
         }
         
         completionHandler()

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -38,7 +38,7 @@ extension SceneDelegate {
         window?.rootViewController = LoginViewController()
     }
     
-    func changeRootViewWithMessageView(roomId: Int) {
+    func changeRootViewWithLetterView(roomId: Int) {
         let rootViewController = UINavigationController(rootViewController: MainViewController())
         let detailIngViewController = DetailingCodebaseViewController(roomId: roomId.description)
         let letterViewController = detailIngViewController.letterViewController

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -37,4 +37,19 @@ extension SceneDelegate {
     func logout() {
         window?.rootViewController = LoginViewController()
     }
+    
+    func changeRootViewWithMessageView(roomId: Int) {
+        let viewController = UINavigationController(rootViewController: MainViewController())
+        let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
+        guard let detailIngviewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
+        let roomInfo = ParticipatingRoom(id: roomId,
+                                         title: nil,
+                                         participatingCount: nil,
+                                         capacity: nil,
+                                         startDate: nil,
+                                         endDate: nil)
+        detailIngviewController.roomInformation = roomInfo
+        viewController.pushViewController(detailIngviewController, animated: true)
+        window?.rootViewController = viewController
+    }
 }

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -41,7 +41,7 @@ extension SceneDelegate {
     func changeRootViewWithMessageView(roomId: Int) {
         let rootViewController = UINavigationController(rootViewController: MainViewController())
         let detailIngViewController = DetailingCodebaseViewController(roomId: roomId.description)
-        let letterViewController = detailIngViewController.letterViewController()
+        let letterViewController = detailIngViewController.letterViewController
         rootViewController.pushViewController(detailIngViewController, animated: true)
         rootViewController.pushViewController(letterViewController, animated: true)
         window?.rootViewController = rootViewController

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -39,11 +39,9 @@ extension SceneDelegate {
     }
     
     func changeRootViewWithLetterView(roomId: Int) {
-        let rootViewController = UINavigationController(rootViewController: MainViewController())
-        let detailIngViewController = DetailingCodebaseViewController(roomId: roomId.description)
-        let letterViewController = detailIngViewController.letterViewController
-        rootViewController.pushViewController(detailIngViewController, animated: true)
-        rootViewController.pushViewController(letterViewController, animated: true)
+        let mainViewController = MainViewController()
+        let rootViewController = UINavigationController(rootViewController: mainViewController)
         window?.rootViewController = rootViewController
+        mainViewController.pushDetailViewController(roomId: roomId)
     }
 }

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -44,4 +44,9 @@ extension SceneDelegate {
         window?.rootViewController = rootViewController
         mainViewController.pushDetailViewController(roomId: roomId)
     }
+    
+    func showRoomIdErrorAlert() {
+        let mainViewController = MainViewController()
+        mainViewController.showRoomIdErrorAlert()
+    }
 }

--- a/Manito/Manito/Global/Supports/SceneDelegate.swift
+++ b/Manito/Manito/Global/Supports/SceneDelegate.swift
@@ -39,17 +39,11 @@ extension SceneDelegate {
     }
     
     func changeRootViewWithMessageView(roomId: Int) {
-        let viewController = UINavigationController(rootViewController: MainViewController())
-        let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)
-        guard let detailIngviewController = storyboard.instantiateViewController(withIdentifier: DetailIngViewController.className) as? DetailIngViewController else { return }
-        let roomInfo = ParticipatingRoom(id: roomId,
-                                         title: nil,
-                                         participatingCount: nil,
-                                         capacity: nil,
-                                         startDate: nil,
-                                         endDate: nil)
-        detailIngviewController.roomInformation = roomInfo
-        viewController.pushViewController(detailIngviewController, animated: true)
-        window?.rootViewController = viewController
+        let rootViewController = UINavigationController(rootViewController: MainViewController())
+        let detailIngViewController = DetailingCodebaseViewController(roomId: roomId.description)
+        let letterViewController = detailIngViewController.letterViewController()
+        rootViewController.pushViewController(detailIngViewController, animated: true)
+        rootViewController.pushViewController(letterViewController, animated: true)
+        window?.rootViewController = rootViewController
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -245,7 +245,10 @@ class DetailIngViewController: BaseViewController {
                   let roomId = self?.roomInformation?.id,
                   let mission = self?.missionContentsLabel.text
             else { return }
-            let letterViewController = LetterViewController(roomState: roomType.rawValue, roomId: roomId.description, mission: mission)
+            let letterViewController = LetterViewController(roomState: roomType.rawValue,
+                                                            roomId: roomId.description,
+                                                            mission: mission,
+                                                            letterState: .sent)
             self?.navigationController?.pushViewController(letterViewController, animated: true)
         }
         letterBoxButton.addAction(action, for: .touchUpInside)

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -23,6 +23,14 @@ final class DetailingCodebaseViewController: BaseViewController {
     private let roomId: String
     private var roomType: RoomType = .PROCESSING
     private var isTappedManittee: Bool = false
+    var letterViewController: UIViewController {
+        guard let mission = missionContentsLabel.text else { return UIViewController() }
+        let viewController = LetterViewController(roomState: roomType.rawValue,
+                                                  roomId: roomId,
+                                                  mission: mission,
+                                                  letterState: .received)
+        return viewController
+    }
 
     // MARK: - property
     
@@ -474,15 +482,6 @@ final class DetailingCodebaseViewController: BaseViewController {
             ])
             exitButton.menu = menu
         }
-    }
-    
-    func letterViewController() -> UIViewController {
-        guard let mission = missionContentsLabel.text else { return UIViewController() }
-        let letterViewController = LetterViewController(roomState: roomType.rawValue,
-                                                        roomId: roomId,
-                                                        mission: mission,
-                                                        letterState: .received)
-        return letterViewController
     }
   
     // MARK: - selector

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -483,6 +483,10 @@ final class DetailingCodebaseViewController: BaseViewController {
             exitButton.menu = menu
         }
     }
+    
+    func pushLetterViewControllerReceivedType() {
+        self.navigationController?.pushViewController(letterViewController, animated: true)
+    }
   
     // MARK: - selector
     

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -133,7 +133,10 @@ final class DetailingCodebaseViewController: BaseViewController {
                   let roomId = self?.roomId,
                   let mission = self?.missionContentsLabel.text
             else { return }
-            let letterViewController = LetterViewController(roomState: roomType.rawValue, roomId: roomId, mission: mission)
+            let letterViewController = LetterViewController(roomState: roomType.rawValue,
+                                                            roomId: roomId,
+                                                            mission: mission,
+                                                            letterState: .sent)
             self?.navigationController?.pushViewController(letterViewController, animated: true)
         }
         button.addAction(action, for: .touchUpInside)
@@ -471,6 +474,15 @@ final class DetailingCodebaseViewController: BaseViewController {
             ])
             exitButton.menu = menu
         }
+    }
+    
+    func letterViewController() -> UIViewController {
+        guard let mission = missionContentsLabel.text else { return UIViewController() }
+        let letterViewController = LetterViewController(roomState: roomType.rawValue,
+                                                        roomId: roomId,
+                                                        mission: mission,
+                                                        letterState: .received)
+        return letterViewController
     }
   
     // MARK: - selector

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -77,7 +77,7 @@ final class LetterViewController: BaseViewController {
     var letterState: LetterState {
         didSet {
             reloadCollectionView(with: self.letterState)
-            setEmptyLabel()
+            setupEmptyLabel()
         }
     }
     
@@ -165,7 +165,7 @@ final class LetterViewController: BaseViewController {
     override func configUI() {
         super.configUI()
         reloadCollectionView(with: self.letterState)
-        setEmptyLabel()
+        setupEmptyLabel()
     }
     
     override func setupNavigationBar() {
@@ -273,7 +273,7 @@ final class LetterViewController: BaseViewController {
         view.addGestureRecognizer(viewTap)
     }
     
-    private func setEmptyLabel() {
+    private func setupEmptyLabel() {
         emptyLabel.text = letterState.labelText
         emptyLabel.isHidden = true
     }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class LetterViewController: BaseViewController {
     
-    private enum LetterState: Int {
+    enum LetterState: Int {
         case sent = 0
         case received = 1
         
@@ -74,11 +74,10 @@ final class LetterViewController: BaseViewController {
     }()
     private lazy var sendLetterView = SendLetterView()
     
-    private var letterState: LetterState = .sent {
+    var letterState: LetterState {
         didSet {
             reloadCollectionView(with: self.letterState)
-            emptyLabel.text = letterState.labelText
-            emptyLabel.isHidden = true
+            setEmptyLabel()
         }
     }
     
@@ -109,10 +108,11 @@ final class LetterViewController: BaseViewController {
     
     // MARK: - init
     
-    init(roomState: String, roomId: String, mission: String) {
+    init(roomState: String, roomId: String, mission: String, letterState: LetterState) {
         self.roomState = roomState
         self.roomId = roomId
         self.mission = mission
+        self.letterState = letterState
         super.init()
     }
     
@@ -164,7 +164,8 @@ final class LetterViewController: BaseViewController {
     
     override func configUI() {
         super.configUI()
-        letterState = .sent
+        reloadCollectionView(with: self.letterState)
+        setEmptyLabel()
     }
     
     override func setupNavigationBar() {
@@ -270,6 +271,11 @@ final class LetterViewController: BaseViewController {
         viewTap.cancelsTouchesInView = false
         navigationController?.view.addGestureRecognizer(navigationTap)
         view.addGestureRecognizer(viewTap)
+    }
+    
+    private func setEmptyLabel() {
+        emptyLabel.text = letterState.labelText
+        emptyLabel.isHidden = true
     }
     
     // MARK: - selector

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -74,7 +74,7 @@ final class LetterViewController: BaseViewController {
     }()
     private lazy var sendLetterView = SendLetterView()
     
-    var letterState: LetterState {
+    private var letterState: LetterState {
         didSet {
             reloadCollectionView(with: self.letterState)
             setupEmptyLabel()

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -285,6 +285,14 @@ final class MainViewController: BaseViewController {
         }
     }
     
+    func pushDetailViewController(roomId: Int) {
+        let viewController = DetailingCodebaseViewController(roomId: roomId.description)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.navigationController?.pushViewController(viewController, animated: true)
+            viewController.pushLetterViewControllerReceivedType()
+        }
+    }
+    
     @objc
     override func endEditingView() {
         if !guideButton.isTouchInside {

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -293,6 +293,10 @@ final class MainViewController: BaseViewController {
         }
     }
     
+    func showRoomIdErrorAlert() {
+        makeRequestAlert(title: "해당 마니또 방의 정보를 불러오지 못했습니다.", message: "해당 마니또 방으로 이동할 수 없습니다.", okAction: nil)
+    }
+    
     @objc
     override func endEditingView() {
         if !guideButton.isTouchInside {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
기존 PR(https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/pull/353) 에서 쪽지가 왔을 때 푸시알림 기능을 구현했습니다. 하지만 푸시알림을 눌러도 그냥 앱에만 들어가지지 어떤 방에서 쪽지가 왔는지는 알 수 없습니다. 그 문제를 해결하기 위해 해당 PR을 작성하게 되었습니다 !

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
마니또로부터 쪽지가 왔을 때 푸시알림이 옵니다. 그 알림을 눌렀을 때 해당 방으로 바로 이동하고, 쪽지함 화면까지 이동합니다. 
### 하지만 여기서 문제가 있었습니다. 

대뜸 쪽지함까지 갔더니 
<img src="https://user-images.githubusercontent.com/78677571/211327832-55a979db-7608-41b8-9bc2-a0df854e1cb0.jpeg" width="300">

이 화면이 떠서 저 조차도 당황스럽더라구요. 이 문제가 발생하는 이유가, 쪽지함의 Segment Controll의 기본값이 내가 마니띠에게 보낸 쪽지를 보여주는 화면이라 생긴 문제였습니다. 그래서 이 Segment를 마니띠로부터 시작하게끔 코드를 추가했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
마니또에게 쪽지를 요청하고, 푸시알림을 눌러서 앱에 들어가보세요 (애니또 릴리즈 톡방에 방을 만들어서 요청하는게 편할겁니다.)


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://user-images.githubusercontent.com/78677571/211328725-624a1f4c-53fd-46c5-b498-1f5509435b31.MP4



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
view들이 너무 독립적이지 못하고 어디 한 쪽에 의존하고 있어서 꽤나 애를 먹었습니다.

1. 서버 통신 횟수를 줄이기 위해 클라쪽에서 데이터들을 전달하다보니 문제가 생겼습니다. 
예시로 `LetterViewController`의 `mission`이란 변수였는데요, 진행중인방 View(DetailIngCodebaseViewController) -> 쪽지함 View(LetterViewController) 로 이동하는 과정에서 초기화하는 방식으로 전달합니다.
처음엔 SceneDelegate에서 1. 홈 화면 2. 진행중 화면 3. 쪽지 함 화면. 이 세개를 UINavigationViewController의 스택으로 바로 쌓아서 rootView를 변경하려니 LetterViewController의 mission을 몰라서 초기화를 할 수가 없었습니다. 그래서 그 정보를 알고있는DetailIngCodebaseViewController에서 LetterViewController를 리턴하는 함수를 만들었습니다.

2. 과거에 왔던 알림을 눌러서 종료된 방의 쪽지함으로 이동했을 때 문제가 생겼습니다.


![image](https://user-images.githubusercontent.com/78677571/211331260-b009addb-a28e-4d98-9660-ee6e922e84b9.png)

위 사진 해당부분이 기본값으로 .PROCESSING으로 초기화 되고 있는데, 

![image](https://user-images.githubusercontent.com/78677571/211331535-3907ddcc-de02-4c47-b7f7-c513201eca0b.png)

viewDidLoad단계에서 해당 API 함수를 통해 값을 변경해주고 있습니다. 하지만 제가 만든 LetterViewController를 리턴하는 함수에서는 

<img width="887" alt="image" src="https://user-images.githubusercontent.com/78677571/211332345-b7088da6-80fa-4e56-a4f7-159968912497.png">
<img width="280" alt="image" src="https://user-images.githubusercontent.com/78677571/211332413-cfe6913d-1499-46e6-84be-0fd47ad9b9e9.png">

해당방은 이미 종료되어서 "POST"가 출력되어야 하는데 "PROCESSING"이 찍힙니다. 왜냐하면  
![image](https://user-images.githubusercontent.com/78677571/211332798-a746da7f-9c07-48f7-8b7d-f02c5a72b36c.png)
SceneDelegate에서 클래스로 바로 초기화만 하고 내부의 함수를 실행하기 때문에 viewDidLoad가 돌지 않습니다. 그래서 POST가 아닌 PROCESSING이 전달됩니다. 

### 그래서 어떤 문제가 발생하는데요??

아래 영상은 이미 마니또가 종료된 방에서 온 푸시알림을 뒤늦게 눌렀을때의 상황입니다.

https://user-images.githubusercontent.com/78677571/211333402-0994f8e0-8c16-489c-b532-62fa8cec9a53.MP4

위 영상에서 보시면 쪽지 쓰기가 가능합니다. 하지만 뒤로 나갔다 들어오면 이미 종료된 방이기 때문에 쪽지 쓰기가 불가능합니다.
이러한 문제가 있습니다... 😭

이 부분들을 어떤식으로 수정해야할지, 애초에 푸시알림을 눌러서 view를 이동하는 방식이 잘못된건지... 잘 모르겠네요.. ㅠ


---

### 다른 분들의 View들을 불가피하게 조금 손보게 되었는데, 그 부분은 슬랙으로 전달드렸습니다 !

<img width="1375" alt="image" src="https://user-images.githubusercontent.com/78677571/211334061-256658c9-a2bc-4152-aa95-3f5e0466457b.png">





## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #357


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
