### PR TITLE
[FEAT] 메인뷰 방목록 로드에 스켈레톤 적용

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -145,7 +145,7 @@
 		CB7B23A828C4ECA8004A4CF3 /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7B23A728C4ECA8004A4CF3 /* Character.swift */; };
 		CB85DE1F28A76F3400399109 /* SettingDeveloperInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85DE1E28A76F3400399109 /* SettingDeveloperInfoHeaderView.swift */; };
 		CB9592B22855C09A00847751 /* ManitoRoomCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9592B12855C09A00847751 /* ManitoRoomCollectionCell.swift */; };
-		CB9592B52855D52700847751 /* CommonMissonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9592B42855D52700847751 /* CommonMissonView.swift */; };
+		CB9592B52855D52700847751 /* CommonMissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9592B42855D52700847751 /* CommonMissionView.swift */; };
 		CBA15C94285CE1A80051EDE2 /* ChooseCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA15C93285CE1A80051EDE2 /* ChooseCharacterViewController.swift */; };
 		CBA4D7A42856CE9F0018BDC2 /* CreateRoomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA4D7A32856CE9F0018BDC2 /* CreateRoomCollectionViewCell.swift */; };
 		CBA4D7A62856D48C0018BDC2 /* RoomStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA4D7A52856D48C0018BDC2 /* RoomStateView.swift */; };
@@ -299,7 +299,7 @@
 		CB7B23A728C4ECA8004A4CF3 /* Character.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Character.swift; sourceTree = "<group>"; };
 		CB85DE1E28A76F3400399109 /* SettingDeveloperInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDeveloperInfoHeaderView.swift; sourceTree = "<group>"; };
 		CB9592B12855C09A00847751 /* ManitoRoomCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManitoRoomCollectionCell.swift; sourceTree = "<group>"; };
-		CB9592B42855D52700847751 /* CommonMissonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonMissonView.swift; sourceTree = "<group>"; };
+		CB9592B42855D52700847751 /* CommonMissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonMissionView.swift; sourceTree = "<group>"; };
 		CBA15C93285CE1A80051EDE2 /* ChooseCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseCharacterViewController.swift; sourceTree = "<group>"; };
 		CBA4D7A32856CE9F0018BDC2 /* CreateRoomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoomCollectionViewCell.swift; sourceTree = "<group>"; };
 		CBA4D7A52856D48C0018BDC2 /* RoomStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStateView.swift; sourceTree = "<group>"; };
@@ -843,7 +843,7 @@
 		CB9592B32855D51100847751 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
-				CB9592B42855D52700847751 /* CommonMissonView.swift */,
+				CB9592B42855D52700847751 /* CommonMissionView.swift */,
 				CBA4D7A52856D48C0018BDC2 /* RoomStateView.swift */,
 			);
 			path = UIComponent;
@@ -1109,7 +1109,7 @@
 				B5F31BB028BE1CA700F61D0F /* UserDefaultStorage.swift in Sources */,
 				B5F31BB228BE1CD700F61D0F /* UserDefaultHandler.swift in Sources */,
 				39CD581D28C4C03C00496E91 /* DetailDoneProtocol.swift in Sources */,
-				CB9592B52855D52700847751 /* CommonMissonView.swift in Sources */,
+				CB9592B52855D52700847751 /* CommonMissionView.swift in Sources */,
 				CBA4D7A42856CE9F0018BDC2 /* CreateRoomCollectionViewCell.swift in Sources */,
 				39C95802287DACC300A04A2B /* RoomEndPoint.swift in Sources */,
 				CB4C77E628C0D4EB007A1AD2 /* MainAPI.swift in Sources */,

--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		CB5AE3E4285AAF7400382EA3 /* RoomInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AE3E3285AAF7400382EA3 /* RoomInfoView.swift */; };
 		CB5AE3E6285AB76800382EA3 /* PeopleInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AE3E5285AB76800382EA3 /* PeopleInfoView.swift */; };
 		CB637A3B28595C1200FF1240 /* ParticipateRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB637A3A28595C1200FF1240 /* ParticipateRoomViewController.swift */; };
+		CB6637E82959CBC60050BD04 /* SkeletonView in Frameworks */ = {isa = PBXBuildFile; productRef = CB6637E72959CBC60050BD04 /* SkeletonView */; };
 		CB674C1C285966020063A6B7 /* InputInvitedCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB674C1B285966020063A6B7 /* InputInvitedCodeView.swift */; };
 		CB674C2128596A310063A6B7 /* CheckRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB674C2028596A310063A6B7 /* CheckRoomViewController.swift */; };
 		CB7B23A828C4ECA8004A4CF3 /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7B23A728C4ECA8004A4CF3 /* Character.swift */; };
@@ -319,6 +320,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB6637E82959CBC60050BD04 /* SkeletonView in Frameworks */,
 				B50B1B0428596C900080992C /* SnapKit in Frameworks */,
 				B50B1B0728596CB10080992C /* FSCalendar in Frameworks */,
 				B50B1B33285AC0970080992C /* Gifu in Frameworks */,
@@ -937,6 +939,7 @@
 				B50B1B0328596C900080992C /* SnapKit */,
 				B50B1B0628596CB10080992C /* FSCalendar */,
 				B50B1B32285AC0970080992C /* Gifu */,
+				CB6637E72959CBC60050BD04 /* SkeletonView */,
 			);
 			productName = Manito;
 			productReference = B5F524CB28519AA000614FF7 /* Manito.app */;
@@ -970,6 +973,7 @@
 				B50B1B0228596C900080992C /* XCRemoteSwiftPackageReference "SnapKit" */,
 				B50B1B0528596CB10080992C /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				B50B1B31285AC0970080992C /* XCRemoteSwiftPackageReference "Gifu" */,
+				CB6637E62959CBC60050BD04 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 			);
 			productRefGroup = B5F524CC28519AA000614FF7 /* Products */;
 			projectDirPath = "";
@@ -1406,6 +1410,14 @@
 				minimumVersion = 3.0.0;
 			};
 		};
+		CB6637E62959CBC60050BD04 /* XCRemoteSwiftPackageReference "SkeletonView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Juanpe/SkeletonView.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1423,6 +1435,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B50B1B31285AC0970080992C /* XCRemoteSwiftPackageReference "Gifu" */;
 			productName = Gifu;
+		};
+		CB6637E72959CBC60050BD04 /* SkeletonView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB6637E62959CBC60050BD04 /* XCRemoteSwiftPackageReference "SkeletonView" */;
+			productName = SkeletonView;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Manito/Manito.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Manito/Manito.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "skeletonview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Juanpe/SkeletonView.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "0f5eaf82e82441690d38abfc4118c961f113881c"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit",

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -19,13 +19,6 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
-    private let greyBackgroundView: UIView = {
-        let uiView = UIView()
-        uiView.backgroundColor = .darkGrey002.withAlphaComponent(0.8)
-        uiView.clipsToBounds = true
-        uiView.makeBorderLayer(color: UIColor.white.withAlphaComponent(0.5))
-        return uiView
-    }()
     private let imageView = UIImageView(image: ImageLiterals.imgNi)
     let memberLabel: UILabel = {
         let label = UILabel()
@@ -55,11 +48,6 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     // MARK: - life cycle
     
     override func render() {
-        addSubview(greyBackgroundView)
-        greyBackgroundView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-
         addSubview(imageView)
         imageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(9)
@@ -95,8 +83,10 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func configUI() {
-//        self.isSkeletonable = true
-        greyBackgroundView.isSkeletonable = false
+        backgroundColor = .darkGrey002.withAlphaComponent(0.8)
+        makeBorderLayer(color: UIColor.white.withAlphaComponent(0.5))
+        
+        self.isSkeletonable = true
         imageView.isSkeletonable = true
         memberLabel.isSkeletonable = true
         roomLabel.isSkeletonable = true

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -88,14 +88,13 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
         
         self.isSkeletonable = true
         imageView.isSkeletonable = true
-        memberLabel.isSkeletonable = true
         roomLabel.isSkeletonable = true
-        dateLabel.isSkeletonable = true
         roomStateView.isSkeletonable = true
+        
+        roomLabel.numberOfLines = 2
 
-        self.memberLabel.numberOfLines = 2
-        self.roomLabel.numberOfLines = 2
-        self.dateLabel.numberOfLines = 2
-        self.skeletonCornerRadius = 10
+        imageView.skeletonCornerRadius = 15
+        roomLabel.linesCornerRadius = 4
+        roomStateView.skeletonCornerRadius = 4
     }
 }

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -48,26 +48,26 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     // MARK: - life cycle
     
     override func render() {
-        addSubview(imageView)
+        contentView.addSubview(imageView)
         imageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(9)
             $0.width.height.equalTo(30)
         }
         
-        addSubview(memberLabel)
+        contentView.addSubview(memberLabel)
         memberLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(14)
             $0.leading.equalTo(imageView.snp.trailing).offset(4)
         }
         
-        addSubview(roomLabel)
+        contentView.addSubview(roomLabel)
         roomLabel.snp.makeConstraints {
             $0.top.equalTo(imageView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(17)
         }
         
-        addSubview(roomStateView)
+        contentView.addSubview(roomStateView)
         roomStateView.snp.makeConstraints {
             $0.top.equalTo(roomLabel.snp.bottom).offset(24)
             $0.leading.equalToSuperview().inset(12)
@@ -75,7 +75,7 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
             $0.height.equalTo(24)
         }
         
-        addSubview(dateLabel)
+        contentView.addSubview(dateLabel)
         dateLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(12)
             $0.centerX.equalToSuperview()
@@ -92,7 +92,10 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
         roomLabel.isSkeletonable = true
         dateLabel.isSkeletonable = true
         roomStateView.isSkeletonable = true
-        
+
+        self.memberLabel.numberOfLines = 2
+        self.roomLabel.numberOfLines = 2
+        self.dateLabel.numberOfLines = 2
         self.skeletonCornerRadius = 10
     }
 }

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -19,6 +19,13 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
+    private let greyBackgroundView: UIView = {
+        let uiView = UIView()
+        uiView.backgroundColor = .darkGrey002.withAlphaComponent(0.8)
+        uiView.clipsToBounds = true
+        uiView.makeBorderLayer(color: UIColor.white.withAlphaComponent(0.5))
+        return uiView
+    }()
     private let imageView = UIImageView(image: ImageLiterals.imgNi)
     let memberLabel: UILabel = {
         let label = UILabel()
@@ -48,6 +55,11 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     // MARK: - life cycle
     
     override func render() {
+        addSubview(greyBackgroundView)
+        greyBackgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
         addSubview(imageView)
         imageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(9)
@@ -83,7 +95,14 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func configUI() {
-        backgroundColor = .darkGrey002.withAlphaComponent(0.8)
-        makeBorderLayer(color: UIColor.white.withAlphaComponent(0.5))
+//        self.isSkeletonable = true
+        greyBackgroundView.isSkeletonable = false
+        imageView.isSkeletonable = true
+        memberLabel.isSkeletonable = true
+        roomLabel.isSkeletonable = true
+        dateLabel.isSkeletonable = true
+        roomStateView.isSkeletonable = true
+        
+        self.skeletonCornerRadius = 10
     }
 }

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import SkeletonView
 import SnapKit
 
 final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
@@ -86,10 +87,9 @@ final class ManitoRoomCollectionViewCell: BaseCollectionViewCell {
         backgroundColor = .darkGrey002.withAlphaComponent(0.8)
         makeBorderLayer(color: UIColor.white.withAlphaComponent(0.5))
         
-        self.isSkeletonable = true
-        imageView.isSkeletonable = true
-        roomLabel.isSkeletonable = true
-        roomStateView.isSkeletonable = true
+        [self, imageView, roomLabel, roomStateView].forEach {
+            $0.isSkeletonable = true
+        }
         
         roomLabel.numberOfLines = 2
 

--- a/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift
@@ -58,6 +58,7 @@ class ManitoRoomCollectionViewCell: UICollectionViewCell{
         super.init(frame: frame)
         setupView()
         render()
+        setupSkeletionView()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -106,5 +107,14 @@ class ManitoRoomCollectionViewCell: UICollectionViewCell{
             $0.bottom.equalToSuperview().inset(12)
             $0.centerX.equalToSuperview()
         }
+    }
+    
+    private func setupSkeletionView() {
+        self.isSkeletonable = true
+        imageView.isSkeletonable = true
+        memberLabel.isSkeletonable = true
+        roomLabel.isSkeletonable = true
+        roomState.isSkeletonable = true
+        dateLabel.isSkeletonable = true
     }
 }

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Gifu
+import SkeletonView
 import SnapKit
 
 final class MainViewController: BaseViewController {
@@ -38,6 +39,8 @@ final class MainViewController: BaseViewController {
             }
         }
     }
+    
+    private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .leftRight)
 
     // MARK: - property
 
@@ -49,7 +52,7 @@ final class MainViewController: BaseViewController {
     }()
     private let imgStar = UIImageView(image: ImageLiterals.imgStar)
     private let commonMissionImageView = UIImageView(image: ImageLiterals.imgCommonMisson)
-    private let commonMissionView = CommonMissonView()
+    private let commonMissionView = CommonMissionView()
     private let menuTitle: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.mainViewControllerMenuTitle
@@ -76,6 +79,7 @@ final class MainViewController: BaseViewController {
             forCellWithReuseIdentifier: ManitoRoomCollectionViewCell.className)
         collectionView.register(cell: CreateRoomCollectionViewCell.self,
             forCellWithReuseIdentifier: CreateRoomCollectionViewCell.className)
+        collectionView.isSkeletonable = true
         return collectionView
     }()
     private let maCharacterImageView = GIFImageView()
@@ -101,8 +105,13 @@ final class MainViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        requestCommonMission()
-        requestManittoList()
+        
+        Task {
+            listCollectionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey002, .lightGray]), animation: skeletonAnimation, transition: .none)
+            requestCommonMission()
+            requestManittoList()
+        }
+
     }
 
     override func render() {
@@ -210,6 +219,9 @@ final class MainViewController: BaseViewController {
                 if let manittoList = data {
                     rooms = manittoList.participatingRooms
                     listCollectionView.reloadData()
+                    
+//                    self.listCollectionView.stopSkeletonAnimation()
+//                    self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
                 }
             } catch NetworkError.serverError {
                 print("serverError")
@@ -293,6 +305,17 @@ final class MainViewController: BaseViewController {
         if !guideButton.isTouchInside {
             guideBoxImageView.isHidden = true
         }
+    }
+}
+
+// MARK: - SkeletonCollectionViewDelegate, SkeletonCollectionViewDataSource
+extension MainViewController: SkeletonCollectionViewDelegate, SkeletonCollectionViewDataSource {
+    func collectionSkeletonView(_ skeletonView: UICollectionView, cellIdentifierForItemAt indexPath: IndexPath) -> ReusableCellIdentifier {
+        ManitoRoomCollectionViewCell.className
+    }
+    
+    func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        8
     }
 }
 

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -150,7 +150,7 @@ final class MainViewController: BaseViewController {
             $0.leading.equalToSuperview().inset(13)
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(30)
         }
-
+        // FIXME: 좌우패딩 20값을 주는데 Size라는 변수명이 겹침
         view.addSubview(commonMissionView)
         commonMissionView.snp.makeConstraints {
             $0.top.equalTo(imgStar.snp.bottom)
@@ -339,11 +339,11 @@ final class MainViewController: BaseViewController {
 // MARK: - SkeletonCollectionViewDelegate, SkeletonCollectionViewDataSource
 extension MainViewController: SkeletonCollectionViewDelegate, SkeletonCollectionViewDataSource {
     func collectionSkeletonView(_ skeletonView: UICollectionView, cellIdentifierForItemAt indexPath: IndexPath) -> ReusableCellIdentifier {
-        ManitoRoomCollectionViewCell.className
+        return ManitoRoomCollectionViewCell.className
     }
     
     func collectionSkeletonView(_ skeletonView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        8
+        return 8
     }
 }
 

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -114,12 +114,8 @@ final class MainViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        Task {
-            requestCommonMission()
-            requestManittoRoomList()
-        }
-
+        requestCommonMission()
+        requestManittoRoomList()
     }
 
     override func render() {

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -222,8 +222,8 @@ final class MainViewController: BaseViewController {
     }
     
     private func stopSkeletonView() {
-        self.listCollectionView.stopSkeletonAnimation()
-        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+//        self.listCollectionView.stopSkeletonAnimation()
+//        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
     }
     
     // MARK: - API

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -109,11 +109,11 @@ final class MainViewController: BaseViewController {
         setupGuideArea()
         renderGuideArea()
         setupRefreshControl()
+        setupSkeletonView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setupSkeletonView()
         
         Task {
             requestCommonMission()
@@ -218,15 +218,12 @@ final class MainViewController: BaseViewController {
     }
     
     private func setupSkeletonView() {
-        commonMissionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey003, .darkGrey002]), animation: skeletonAnimation, transition: .none)
         listCollectionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey003, .darkGrey002]), animation: skeletonAnimation, transition: .none)
     }
     
     private func stopSkeletonView() {
-        self.commonMissionView.stopSkeletonAnimation()
-        self.commonMissionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
-        self.listCollectionView.stopSkeletonAnimation()
-        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+//        self.listCollectionView.stopSkeletonAnimation()
+//        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
     }
     
     // MARK: - API

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -24,6 +24,8 @@ final class MainViewController: BaseViewController {
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,
                                                   right: collectionHorizontalSpacing)
+        static let commonMissionViewWidth: CGFloat = UIScreen.main.bounds.size.width - 48
+        static let commonMissionViewHeight: CGFloat = commonMissionViewWidth * 0.6
     }
     
     private enum RoomStatus: String {
@@ -43,7 +45,7 @@ final class MainViewController: BaseViewController {
         }
     }
     
-    private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .leftRight)
+    private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .topLeftBottomRight)
     
     private let refreshControl = UIRefreshControl()
 
@@ -59,7 +61,6 @@ final class MainViewController: BaseViewController {
         return button
     }()
     private let imgStar = UIImageView(image: ImageLiterals.imgStar)
-    private let commonMissionImageView = UIImageView(image: ImageLiterals.imgCommonMisson)
     private let commonMissionView = CommonMissionView()
     private let menuTitle: UILabel = {
         let label = UILabel()
@@ -112,9 +113,9 @@ final class MainViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        setupSkeletonView()
         
         Task {
-            listCollectionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey002, .lightGray]), animation: skeletonAnimation, transition: .none)
             requestCommonMission()
             requestManittoRoomList()
         }
@@ -150,22 +151,16 @@ final class MainViewController: BaseViewController {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(30)
         }
 
-        view.addSubview(commonMissionImageView)
-        commonMissionImageView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(commonMissionImageView.snp.width).multipliedBy(0.61)
-            $0.top.equalTo(imgStar.snp.bottom)
-        }
-
-        commonMissionImageView.addSubview(commonMissionView)
+        view.addSubview(commonMissionView)
         commonMissionView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.top.equalTo(imgStar.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(Size.commonMissionViewHeight)
         }
 
         view.addSubview(menuTitle)
         menuTitle.snp.makeConstraints {
-            $0.top.equalTo(commonMissionImageView.snp.bottom).offset(50)
+            $0.top.equalTo(commonMissionView.snp.bottom).offset(50)
             $0.leading.equalToSuperview().offset(16)
         }
 
@@ -177,7 +172,7 @@ final class MainViewController: BaseViewController {
         
         view.addSubview(guideButton)
         guideButton.snp.makeConstraints {
-            $0.top.equalTo(commonMissionImageView.snp.top).offset(27)
+            $0.top.equalTo(commonMissionView.snp.top).offset(27)
             $0.trailing.equalTo(commonMissionView.snp.trailing)
             $0.width.height.equalTo(44)
         }
@@ -222,6 +217,17 @@ final class MainViewController: BaseViewController {
         listCollectionView.refreshControl = refreshControl
     }
     
+    private func setupSkeletonView() {
+        commonMissionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey003, .darkGrey002]), animation: skeletonAnimation, transition: .none)
+        listCollectionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.grey003, .darkGrey002]), animation: skeletonAnimation, transition: .none)
+    }
+    
+    private func stopSkeletonView() {
+        self.commonMissionView.stopSkeletonAnimation()
+        self.listCollectionView.stopSkeletonAnimation()
+        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+    }
+    
     // MARK: - API
     
     private func requestCommonMission() {
@@ -248,8 +254,7 @@ final class MainViewController: BaseViewController {
                     rooms = manittoList.participatingRooms
                     listCollectionView.reloadData()
                     
-//                    self.listCollectionView.stopSkeletonAnimation()
-//                    self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+                    self.stopSkeletonView()
                 }
             } catch NetworkError.serverError {
                 print("serverError")

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -24,7 +24,7 @@ final class MainViewController: BaseViewController {
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,
                                                   right: collectionHorizontalSpacing)
-        static let commonMissionViewWidth: CGFloat = UIScreen.main.bounds.size.width - 48
+        static let commonMissionViewWidth: CGFloat = UIScreen.main.bounds.size.width - 40
         static let commonMissionViewHeight: CGFloat = commonMissionViewWidth * 0.6
     }
     
@@ -154,7 +154,7 @@ final class MainViewController: BaseViewController {
         view.addSubview(commonMissionView)
         commonMissionView.snp.makeConstraints {
             $0.top.equalTo(imgStar.snp.bottom)
-            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(Size.commonMissionViewHeight)
         }
 
@@ -172,8 +172,8 @@ final class MainViewController: BaseViewController {
         
         view.addSubview(guideButton)
         guideButton.snp.makeConstraints {
-            $0.top.equalTo(commonMissionView.snp.top).offset(27)
-            $0.trailing.equalTo(commonMissionView.snp.trailing)
+            $0.top.equalTo(commonMissionView.snp.top).offset(30)
+            $0.trailing.equalTo(commonMissionView.snp.trailing).inset(30)
             $0.width.height.equalTo(44)
         }
     }
@@ -224,6 +224,7 @@ final class MainViewController: BaseViewController {
     
     private func stopSkeletonView() {
         self.commonMissionView.stopSkeletonAnimation()
+        self.commonMissionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
         self.listCollectionView.stopSkeletonAnimation()
         self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
     }

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -222,8 +222,8 @@ final class MainViewController: BaseViewController {
     }
     
     private func stopSkeletonView() {
-//        self.listCollectionView.stopSkeletonAnimation()
-//        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+        self.listCollectionView.stopSkeletonAnimation()
+        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
     }
     
     // MARK: - API

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -45,7 +45,7 @@ final class MainViewController: BaseViewController {
         }
     }
     
-    private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .topLeftBottomRight)
+    private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .leftRight)
     
     private let refreshControl = UIRefreshControl()
 

--- a/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
+++ b/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
@@ -47,20 +47,19 @@ final class CommonMissionView: UIView {
     private func render() {
         self.addSubview(commonMissionImageView)
         commonMissionImageView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(commonMissionImageView.snp.width).multipliedBy(0.61)
+            $0.edges.equalToSuperview()
         }
         
         self.addSubview(title)
         title.snp.makeConstraints {
-            $0.top.centerX.equalToSuperview()
+            $0.top.equalToSuperview().inset(56)
+            $0.centerX.equalToSuperview()
         }
         
         self.addSubview(mission)
         mission.snp.makeConstraints {
-            $0.top.equalTo(self.title.snp.bottom).offset(23)
-            $0.bottom.leading.trailing.equalToSuperview()
-            $0.height.equalTo(56)
+            $0.top.equalTo(title.snp.bottom).offset(40)
+            $0.leading.trailing.equalToSuperview()
         }
     }
     

--- a/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
+++ b/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
@@ -13,6 +13,7 @@ final class CommonMissionView: UIView {
     
     // MARK: - property
     
+    private let commonMissionImageView = UIImageView(image: ImageLiterals.imgCommonMisson)
     private let title: UILabel = {
         let label = UILabel()
         label.text = TextLiteral.commonMissionViewTitle
@@ -34,6 +35,7 @@ final class CommonMissionView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
+        configUI()
     }
     
     required init?(coder: NSCoder) {
@@ -43,6 +45,12 @@ final class CommonMissionView: UIView {
     // MARK: - life cycle
     
     private func render() {
+        self.addSubview(commonMissionImageView)
+        commonMissionImageView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(commonMissionImageView.snp.width).multipliedBy(0.61)
+        }
+        
         self.addSubview(title)
         title.snp.makeConstraints {
             $0.top.centerX.equalToSuperview()
@@ -54,5 +62,9 @@ final class CommonMissionView: UIView {
             $0.bottom.leading.trailing.equalToSuperview()
             $0.height.equalTo(56)
         }
+    }
+    
+    private func configUI() {
+        self.isSkeletonable = true
     }
 }

--- a/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
+++ b/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
@@ -1,5 +1,5 @@
 //
-//  CommonMissonView.swift
+//  CommonMissionView.swift
 //  Manito
 //
 //  Created by COBY_PRO on 2022/06/12.
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class CommonMissonView: UIView {
+final class CommonMissionView: UIView {
     
     // MARK: - property
     

--- a/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
+++ b/Manito/Manito/Screens/Main/UIComponent/CommonMissionView.swift
@@ -35,7 +35,6 @@ final class CommonMissionView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
-        configUI()
     }
     
     required init?(coder: NSCoder) {
@@ -61,9 +60,5 @@ final class CommonMissionView: UIView {
             $0.top.equalTo(title.snp.bottom).offset(40)
             $0.leading.trailing.equalToSuperview()
         }
-    }
-    
-    private func configUI() {
-        self.isSkeletonable = true
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
메인뷰에서 스켈레톤으로 방목록을 로드하는 기능을 추가하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### Skeleton 적용
`SkeletonView` 라이브러리를 먼저 설치하였습니다.
그리고 `MainViewController`에 skeletonAnimation를 선언해주었습니다.
`private let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .leftRight)`
애니메이션 방향은`leftRight`, 왼쪽에서 오른쪽으로 설정하여, 로딩을 기다리는 시간을 덜 지루하게 하였습니다.
(cf. 왼쪽에서 오른쪽으로 진행되는 애니메이션의 로딩 체감 시간이 가장 짧다고 합니다.)

그리고 방목록 컬렉션뷰에 스켈레톤 애니메이션을 적용시키기 위해, 스켈레톤 컬렉션뷰를 따로 만들어주었습니다.
https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/blob/e2a934dd2b0be75539c6e76803e6632046ce3971/Manito/Manito/Screens/Main/MainViewController.swift#L339-L348

![image](https://user-images.githubusercontent.com/57849386/212870943-85bc893e-aac7-49d4-988f-4bb1e936a2a5.png)

스켈레톤을 적용하고자 하는 요소에 `isSkeleton = true`를 해주면, 스켈레톤 애니메이션이 적용되게 됩니다.
SkeletonView 은 재귀적이기 때문에 부모뷰에 true값을 주어야 자식뷰에도 적용됩니다.

### etc.
기존 `MainViewController`에서 CommisionView와 터미널 이미지가 따로 있는 것을 확인하여, CommisionView안으로 이미지를 넣고, `render`에서 다른 뷰와의 관계를 재정의하였습니다.

### 01.19 코드리뷰 반영 및 수정내용
스켈레톤에 radius값을 주어서 좀 더 자연스로운 뷰를 연출하였습니다. 하단의 세번째 스크린샷으로 두었어요.
https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/blob/d9271222d25d3722caa2ce3e6ebcef7bcbdd7888/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift#L96-L98


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`MainViewController`의 `stopSkeletonView`의 함수 내부를 주석처리하시면, 스켈레톤 애니메이션이 멈추지 않습니다.
```
    private func stopSkeletonView() {
        self.listCollectionView.stopSkeletonAnimation()
        self.listCollectionView.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
    }
```

## 📱 Screenshot
<p align="left">
<img src="https://user-images.githubusercontent.com/57849386/212869454-aa19fe32-d56d-47f8-8d5c-cbb200a1413e.gif" width="200"> 
<img src="https://user-images.githubusercontent.com/57849386/212869289-3e36a1d0-c2c2-4b4f-8976-97d6e2a0242d.gif" width="200"> 
<img src="https://user-images.githubusercontent.com/57849386/213432024-ac947ca1-e459-493b-bd74-5d9043a22231.gif" width="200"> 
</p>


## 📝 Review Note

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 PR에 올린 결과물은 상단 스크린샷의 오른쪽에 해당합니다.
왼쪽 스크린샷에서 오른쪽 스크린샷으로 가기까지 많이 험난했는데요. 해결은 어쩌다(?) 되었습니다.

방목록 셀 전체가 아니라, 셀 내부의 요소들에도 스켈레톤 애니메이션을 적용을 시키고 싶었는데 도통... 되지 않았습니다.
해결한 방법은 셀의 render()함수에서 `addSubView`를 `contentView.addSubvView`를 수정한 것입니다.
https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/blob/e2a934dd2b0be75539c6e76803e6632046ce3971/Manito/Manito/Screens/Main/Cell/ManitoRoomCollectionCell.swift#L50-L55

contentView에서 화면을 그려야만, 내부 프로퍼티에도 스켈레톤뷰가 적용이 되는 것에 대해서 명쾌하게 이해를 하지 못한 상태입니다.
같이 고민해주실분...

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #352

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://gyuios.tistory.com/63
https://velog.io/@dvhuni/iOS-SkeletonView-%EC%B0%8D%EC%96%B4%EB%A8%B9%EA%B8%B0
