### PR TITLE
[FEAT] 카메라 권한 관련 코드 추가 및 Picker Delegate 코드 수정

### DIFF
--- a/Manito/Manito/Global/Extension/UIViewController+Extension.swift
+++ b/Manito/Manito/Global/Extension/UIViewController+Extension.swift
@@ -25,6 +25,7 @@ extension UIViewController {
                           message: String,
                           okTitle: String = "확인",
                           cancelTitle: String = "취소",
+                          okStyle: UIAlertAction.Style = .destructive,
                           okAction: ((UIAlertAction) -> Void)?,
                           cancelAction: ((UIAlertAction) -> Void)? = nil,
                           completion : (() -> Void)? = nil) {
@@ -37,7 +38,7 @@ extension UIViewController {
         let cancelAction = UIAlertAction(title: cancelTitle, style: .default, handler: cancelAction)
         alertViewController.addAction(cancelAction)
         
-        let okAction = UIAlertAction(title: okTitle, style: .destructive, handler: okAction)
+        let okAction = UIAlertAction(title: okTitle, style: okStyle, handler: okAction)
         alertViewController.addAction(okAction)
         
         self.present(alertViewController, animated: true, completion: completion)

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 enum TextLiteral {
+
+    // MARK: - App Name
+    static let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "애니또"
     
     // MARK: - AnyWhere
     static let done: String = "완료"
@@ -107,6 +110,10 @@ enum TextLiteral {
     static let letterPhotoViewChoosePhotoToManitto: String = "마니또에게 보낼 사진 선택"
     static let letterPhotoViewSetting: String = "설정"
     static let letterPhotoViewFail: String = "사진을 불러올 수 없습니다."
+    static let letterPhotoViewErrorTitle: String = "오류"
+    static let letterPhotoViewSettingFail = "설정 화면을 연결할 수 없습니다."
+    static let letterPhotoViewDeviceFail = "해당 기기에서 카메라를 사용할 수 없습니다."
+    static let letterPhotoViewSettingAuthorization = "\(appName)가 카메라에 접근이 허용되어 있지 않습니다. 설정화면으로 가시겠습니까?"
     
     // MARK: - LetterViewController
     static let letterViewControllerTitle = "쪽지함"

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -174,6 +174,11 @@ final class CreateLetterPhotoView: UIView {
     }
 
     private func checkImagePickerControllerAccessRight() {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            self.viewController?.makeAlert(title: "오류", message: "해당 기기에서 카메라를 사용할 수 없습니다.")
+            return
+        }
+
         AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
             DispatchQueue.main.async {
                 granted ? self?.imagePickerControllerDidShow() : self?.openSettings()
@@ -182,7 +187,6 @@ final class CreateLetterPhotoView: UIView {
     }
 
     private func imagePickerControllerDidShow() {
-        guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return }
         let imagePickerController = UIImagePickerController()
         imagePickerController.delegate = self
         imagePickerController.sourceType = .camera

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -158,7 +158,7 @@ final class CreateLetterPhotoView: UIView {
     }
     
     private func openSettings() {
-        let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "애니또"
+        let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "애니또"
         let settingAction: alertAction = { [weak self] _ in
             guard let settingURL = URL(string: UIApplication.openSettingsURLString) else {
                 self?.viewController?.makeAlert(title: "오류", message: "설정 화면을 연결할 수 없습니다.")

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -192,9 +192,9 @@ final class CreateLetterPhotoView: UIView {
             return
         }
 
-        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] hasGranted in
             DispatchQueue.main.async {
-                granted ? self?.imagePickerControllerDidShow() : self?.openSettings()
+                hasGranted ? self?.imagePickerControllerDidShow() : self?.openSettings()
             }
         }
     }

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -5,6 +5,7 @@
 //  Created by SHIN YOON AH on 2022/06/13.
 //
 
+import AVFoundation
 import PhotosUI
 import UIKit
 

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -188,6 +188,8 @@ final class CreateLetterPhotoView: UIView {
 
         self.viewController?.makeRequestAlert(title: TextLiteral.letterPhotoViewSetting,
                                               message: TextLiteral.letterPhotoViewSettingAuthorization,
+                                              okTitle: "설정",
+                                              okStyle: .default,
                                               okAction: settingAction,
                                               completion: nil)
     }

--- a/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
+++ b/Manito/Manito/Screens/Letter/UIComponent/CreateLetterPhotoView.swift
@@ -171,24 +171,25 @@ final class CreateLetterPhotoView: UIView {
     }
     
     private func openSettings() {
-        let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "애니또"
         let settingAction: alertAction = { [weak self] _ in
             guard let settingURL = URL(string: UIApplication.openSettingsURLString) else {
-                self?.viewController?.makeAlert(title: "오류", message: "설정 화면을 연결할 수 없습니다.")
+                self?.viewController?.makeAlert(title: TextLiteral.letterPhotoViewErrorTitle,
+                                                message: TextLiteral.letterPhotoViewSettingFail)
                 return
             }
             UIApplication.shared.open(settingURL)
         }
 
         self.viewController?.makeRequestAlert(title: TextLiteral.letterPhotoViewSetting,
-                                              message: "\(appName)가 카메라에 접근이 허용되어 있지 않습니다. 설정화면으로 가시겠습니까?",
+                                              message: TextLiteral.letterPhotoViewSettingAuthorization,
                                               okAction: settingAction,
                                               completion: nil)
     }
 
     private func checkImagePickerControllerAccessRight() {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
-            self.viewController?.makeAlert(title: "오류", message: "해당 기기에서 카메라를 사용할 수 없습니다.")
+            self.viewController?.makeAlert(title: TextLiteral.letterPhotoViewErrorTitle,
+                                           message: TextLiteral.letterPhotoViewDeviceFail)
             return
         }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
* #379 PR을 진행하면서 발견한 카메라 권한, Picker Delegate 코드 관련 문제들을 해결했습니다.

⓵ 현재 카메라를 통해서 사진을 가져올 때, 카메라에 대한 접근 권한이 없으면 따로 alert가 뜨지 않고 검은 화면으로 넘어갑니다. 라이브러리 접근 권한이 없을 때 설정으로 보내주는 것처럼 카메라도 접근 권한이 없으면 설정으로 보내는 작업을 하려고 합니다.

⓶ PHPickerController Delegate 함수 내부가 load에 대한 에러 처리라던지, ui부분과 image를 load하는 함수들이 섞여 있어서 읽기가 쉽지 않은거 같아서 분리를 해보려고 합니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

### ➰ 카메라 관련 권한 확인 코드를 추가했습니다.
총 두 가지 권한을 확인했습니다. ⓵ SoureType(카메라)이 사용 가능한 상태인지 ⓶ 현재 Access가 가능한지 를 확인했습니다.
```swift
    private func checkImagePickerControllerAccessRight() {
        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
            self.viewController?.makeAlert(title: "오류", message: "해당 기기에서 카메라를 사용할 수 없습니다.")
            return
        }

        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
            DispatchQueue.main.async {
                granted ? self?.imagePickerControllerDidShow() : self?.openSettings()
            }
        }
    }
```
<br>

### ➰ PHPicker(라이브러리)에서 사진을 가져올 때 image를 로드하는 부분을 분리했습니다.
현재 PHPickViewControllerDelegate 안에 있는 함수 Picker 내부에 이미지를 로드하는 코드와 결과를 받아와서 UI에 넣어주는 코드가 섞여있어서 이 부분을 분리해주었습니다.

이미지를 로드하는 부분을 따로 만들고 completionHandler를 통해서 Result 값을 받도록 했습니다.
```swift
    private func loadUIImage(for itemProvider: NSItemProvider, completionHandler: @escaping ((Result<UIImage, PHLibraryError>) -> ())) {
        guard itemProvider.canLoadObject(ofClass: UIImage.self) else { completionHandler(.failure(.loadError)); return }

        itemProvider.loadObject(ofClass: UIImage.self) { image, error in
            if error != nil {
                completionHandler(.failure(.loadError))
            }

            if let image = image as? UIImage {
                completionHandler(.success(image))
            }
        }
    }
```

Result에서 Error는 따로 PHLibraryError를 만들어서 사용했습니다.
```swift
    
    private enum PHLibraryError: Error {
        case loadError

        var errorDescription: String {
            switch self {
            case .loadError:
                return TextLiteral.letterPhotoViewFail
            }
        }
    }
```

<br>

### ➰ 앱 이름을 가져오는 부분에서 `CFBundleName`말고 `CFBundleDisplayName`을 가져오도록 했습니다.
CFBundleName은 Manitto라는 프로젝트 이름을 가져오고 있더라구요. 그래서 애니또라는 이름을 가져올 수도 있도록 수정했습니다.

지금은 애니또로 잘 들어오고 있습니다.
<img src="https://user-images.githubusercontent.com/55099365/218964246-078c21ff-b1c8-4e34-8947-55cb4d2b2131.jpeg" width="350">

<br>

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

⓵ 설정창에서 애니또를 눌러서 카메라, 사진 권한을 없애줍니다.
⓶ 애니또에서 카메라, 사진 보관함에서 선택을 눌렀을 때 알림창이 잘 뜨는 지 확인해주십쇼.
⓷ 알림창에서 확인버튼을 눌렀을때 설정 화면으로 잘 가는지 확인해주십쇼.

feature/378-camera-permission 브랜치에서 진행해주시면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

한가지 고민이 되는 부분이 있습니다. 알림창에서 설정으로 가겠습니까? 라고 뜰 때, `확인`이라는 단어가 좋을지, `설정`이라는 단어가 좋을지 고민이 됩니다. 다른 앱같은 경우에는 설정이라고 적혀있는 경우들이 있더라구요. 
다른 분들의 생각은 어떤지 궁금합니다.!
<img width="300" alt="스크린샷 2023-02-15 오후 4 50 37" src="https://user-images.githubusercontent.com/55099365/218965477-4e72f75f-b6ba-4b63-833a-b1bfa108c064.png">


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #378 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
* 카메라 권한 설정 참고 : https://hello-bryan.tistory.com/355