### PR TITLE
[FIX] 마니또 공개 텍스트 잘림 현상 해결

### DIFF
--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -18,7 +18,7 @@ final class OpenManittoPopupViewController: BaseViewController {
     private lazy var typingLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 2
-        label.font = .font(.regular, ofSize: 30)
+        label.font = .font(.regular, ofSize: 24)
         label.adjustsFontSizeToFitWidth = true
         label.textAlignment = .center
         return label

--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -19,6 +19,7 @@ final class OpenManittoPopupViewController: BaseViewController {
         let label = UILabel()
         label.numberOfLines = 2
         label.font = .font(.regular, ofSize: 30)
+        label.adjustsFontSizeToFitWidth = true
         label.textAlignment = .center
         return label
     }()

--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -81,7 +81,7 @@ final class OpenManittoPopupViewController: BaseViewController {
         typingLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(popupView.frame.height * 0.36)
             $0.centerX.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(10)
+            $0.leading.trailing.equalToSuperview().inset(24)
         }
         
         popupView.addSubview(openMentLabel)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img src="https://user-images.githubusercontent.com/78677571/220112969-9aae0b1a-1add-456c-b7e3-81465d23b98f.PNG" width="300">
호야가 제보해준 마니또가 누군지 알 수 없는 현상에 대해 수정했습니다 !

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 사이즈에 맞춰 폰트 크기 조절
- 좌우 inset값 10 -> 24로 수정


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
전 마니또 공개까지 가기 번거로워서 SceneDelegate 에서 rootView를 아래와 같이 변경 후 실행했습니다.
```swift
let testViewController = OpenManittoPopupViewController()
window.rootViewController = testViewController
```

사진으로 보여드리자면 
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/78677571/220113663-8b5d67d3-dc1e-44ec-9e90-a7a4cf95b65e.png">


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->
|iPhone 13 mini|iPhone 14 Pro|
|---|---|
|<img src="https://user-images.githubusercontent.com/78677571/220115069-ed8a7b40-9eec-4a6e-bd69-20f7955033c8.gif" width="300">|<img src="https://user-images.githubusercontent.com/78677571/220115052-7686a3c8-1edc-47c4-ba8c-880d3612cda4.gif" width="300">|




## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

기존의 코드에서 사이즈에 맞게 폰트를 줄이는 코드만 추가하니까 아래 사진과 같이 좌우를 초과하는 문제가 있어서 

|iPhone 13 mini|iPhone 14 Pro|
|---|---|
|<img src="https://user-images.githubusercontent.com/78677571/220115667-c5a21c3f-e8af-426c-8752-23d8ee3964f6.png" width="300">|<img src="https://user-images.githubusercontent.com/78677571/220115650-01f00713-e60a-40ed-9063-37f5ae1f5816.png" width="300">|

`$0.leading.trailing.equalToSuperview().inset(10)` 값을 24로 수정했습니다.
24도 조금 모자란 것 같다면 말씀해주세요 ! 값을 더 올리겠습니다 ^_________^

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #382 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
