### PR TITLE
[REFACTOR] LetterImageViewController에서 View를 분리했습니다.

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		B517C04A28D1F7EC0008BED0 /* TokenEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517C04928D1F7EC0008BED0 /* TokenEndPoint.swift */; };
 		B517C04C28D1FE5F0008BED0 /* TokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517C04B28D1FE5F0008BED0 /* TokenAPI.swift */; };
 		B517C04E28D1FE660008BED0 /* TokenProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517C04D28D1FE660008BED0 /* TokenProtocol.swift */; };
+		B54741E029A3A4DB00B75BA3 /* LetterImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54741DF29A3A4DB00B75BA3 /* LetterImageView.swift */; };
 		B55BCEB428D8449E00AF7E45 /* MemoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEB328D8449E00AF7E45 /* MemoryCollectionViewCell.swift */; };
 		B55BCEB628D99F8600AF7E45 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEB528D99F8600AF7E45 /* Settings.bundle */; };
 		B55BCEC628F5AFB200AF7E45 /* capsule.gif in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEC528F5AFB200AF7E45 /* capsule.gif */; };
@@ -238,6 +239,7 @@
 		B517C04928D1F7EC0008BED0 /* TokenEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenEndPoint.swift; sourceTree = "<group>"; };
 		B517C04B28D1FE5F0008BED0 /* TokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAPI.swift; sourceTree = "<group>"; };
 		B517C04D28D1FE660008BED0 /* TokenProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProtocol.swift; sourceTree = "<group>"; };
+		B54741DF29A3A4DB00B75BA3 /* LetterImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageView.swift; sourceTree = "<group>"; };
 		B55BCEB328D8449E00AF7E45 /* MemoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		B55BCEB528D99F8600AF7E45 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		B55BCEC528F5AFB200AF7E45 /* capsule.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = capsule.gif; sourceTree = "<group>"; };
@@ -492,6 +494,14 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		B54741DE29A3A4BA00B75BA3 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B54741DF29A3A4DB00B75BA3 /* LetterImageView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		B5F31BAE28BE1C7900F61D0F /* Storage */ = {
 			isa = PBXGroup;
 			children = (
@@ -618,6 +628,7 @@
 		B5F524EA28519B4B00614FF7 /* Letter */ = {
 			isa = PBXGroup;
 			children = (
+				B54741DE29A3A4BA00B75BA3 /* View */,
 				B5F5253328547EE000614FF7 /* UIComponent */,
 				B5F5253228547CAF00614FF7 /* Cell */,
 				B5F5250D2851A07700614FF7 /* LetterViewController.swift */,
@@ -1146,6 +1157,7 @@
 				CB358C0228A564080084D001 /* SettingDeveloperInfoViewController.swift in Sources */,
 				CB7B23A828C4ECA8004A4CF3 /* Character.swift in Sources */,
 				39C957E12879A3CF00A04A2B /* DailyMission.swift in Sources */,
+				B54741E029A3A4DB00B75BA3 /* LetterImageView.swift in Sources */,
 				39CD582128C4C3E800496E91 /* DetailDoneAPI.swift in Sources */,
 				D724AF5D287088310003F280 /* SettingViewController.swift in Sources */,
 				B5F5253D2854B8CB00614FF7 /* UIView+Extension.swift in Sources */,

--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		B517C04C28D1FE5F0008BED0 /* TokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517C04B28D1FE5F0008BED0 /* TokenAPI.swift */; };
 		B517C04E28D1FE660008BED0 /* TokenProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517C04D28D1FE660008BED0 /* TokenProtocol.swift */; };
 		B54741E029A3A4DB00B75BA3 /* LetterImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54741DF29A3A4DB00B75BA3 /* LetterImageView.swift */; };
+		B54741EA29A494E200B75BA3 /* LetterImageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54741E929A494E200B75BA3 /* LetterImageError.swift */; };
 		B55BCEB428D8449E00AF7E45 /* MemoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEB328D8449E00AF7E45 /* MemoryCollectionViewCell.swift */; };
 		B55BCEB628D99F8600AF7E45 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEB528D99F8600AF7E45 /* Settings.bundle */; };
 		B55BCEC628F5AFB200AF7E45 /* capsule.gif in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEC528F5AFB200AF7E45 /* capsule.gif */; };
@@ -240,6 +241,7 @@
 		B517C04B28D1FE5F0008BED0 /* TokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAPI.swift; sourceTree = "<group>"; };
 		B517C04D28D1FE660008BED0 /* TokenProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProtocol.swift; sourceTree = "<group>"; };
 		B54741DF29A3A4DB00B75BA3 /* LetterImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageView.swift; sourceTree = "<group>"; };
+		B54741E929A494E200B75BA3 /* LetterImageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageError.swift; sourceTree = "<group>"; };
 		B55BCEB328D8449E00AF7E45 /* MemoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		B55BCEB528D99F8600AF7E45 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		B55BCEC528F5AFB200AF7E45 /* capsule.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = capsule.gif; sourceTree = "<group>"; };
@@ -502,6 +504,30 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		B54741E529A4945100B75BA3 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				B54741E629A4945A00B75BA3 /* Screens */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
+		B54741E629A4945A00B75BA3 /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				B54741E729A4947C00B75BA3 /* Letter */,
+			);
+			path = Screens;
+			sourceTree = "<group>";
+		};
+		B54741E729A4947C00B75BA3 /* Letter */ = {
+			isa = PBXGroup;
+			children = (
+				B54741E929A494E200B75BA3 /* LetterImageError.swift */,
+			);
+			path = Letter;
+			sourceTree = "<group>";
+		};
 		B5F31BAE28BE1C7900F61D0F /* Storage */ = {
 			isa = PBXGroup;
 			children = (
@@ -563,6 +589,7 @@
 		B5F524E428519AC600614FF7 /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				B54741E529A4945100B75BA3 /* Error */,
 				B5F525272851A29C00614FF7 /* Utils */,
 				B5F524F828519BC700614FF7 /* Literal */,
 				B5F524F728519BC400614FF7 /* Base */,
@@ -1070,6 +1097,7 @@
 				399D17AB2856C83B00F50D9D /* DetailEditViewController.swift in Sources */,
 				7E15F67E28B35B3D00441305 /* TextLiteral.swift in Sources */,
 				39C957DD2879A2B600A04A2B /* Room.swift in Sources */,
+				B54741EA29A494E200B75BA3 /* LetterImageError.swift in Sources */,
 				B5F525422855C97900614FF7 /* UILabel+Extension.swift in Sources */,
 				CB21C33928C4C10200128D25 /* CharacterCollectionViewCell.swift in Sources */,
 				39EEF65A28CB3C7B00437654 /* Token.swift in Sources */,

--- a/Manito/Manito/Global/Error/Screens/Letter/LetterImageError.swift
+++ b/Manito/Manito/Global/Error/Screens/Letter/LetterImageError.swift
@@ -1,0 +1,22 @@
+//
+//  LetterImageError.swift
+//  Manito
+//
+//  Created by SHIN YOON AH on 2023/02/21.
+//
+
+import Foundation
+
+enum LetterImageError: LocalizedError {
+    case invalidImage
+    case invalidPhotoLibrary
+}
+
+extension LetterImageError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidImage: return TextLiteral.letterImageViewControllerErrorMessage
+        case .invalidPhotoLibrary: return TextLiteral.letterImageViewControllerErrorMessage
+        }
+    }
+}

--- a/Manito/Manito/Screens/Detail-Ing/MemoryViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/MemoryViewController.swift
@@ -292,7 +292,7 @@ extension MemoryViewController: UICollectionViewDataSource {
                          content: memory?.memoriesWithManitto?.messages?[indexPath.item].content)
         }
         cell.didTappedImage = { [weak self] image in
-            let viewController = LetterImageViewController(image: image)
+            let viewController = LetterImageViewController(imageUrl: (self?.memory?.memoriesWithManittee?.messages?[indexPath.item].imageUrl)!)
             viewController.modalPresentationStyle = .fullScreen
             viewController.modalTransitionStyle = .crossDissolve
             self?.present(viewController, animated: true)

--- a/Manito/Manito/Screens/Detail-Ing/MemoryViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/MemoryViewController.swift
@@ -283,20 +283,26 @@ extension MemoryViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell: MemoryCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
+        var imageUrl: String
+
         switch memoryType {
         case .manittee:
+            imageUrl = memory?.memoriesWithManittee?.messages?[indexPath.item].imageUrl ?? ""
             cell.setData(imageUrl: memory?.memoriesWithManittee?.messages?[indexPath.item].imageUrl,
                          content: memory?.memoriesWithManittee?.messages?[indexPath.item].content)
         case .manitto:
+            imageUrl = memory?.memoriesWithManitto?.messages?[indexPath.item].imageUrl ?? ""
             cell.setData(imageUrl: memory?.memoriesWithManitto?.messages?[indexPath.item].imageUrl,
                          content: memory?.memoriesWithManitto?.messages?[indexPath.item].content)
         }
+
         cell.didTappedImage = { [weak self] image in
-            let viewController = LetterImageViewController(imageUrl: (self?.memory?.memoriesWithManittee?.messages?[indexPath.item].imageUrl)!)
+            let viewController = LetterImageViewController(imageUrl: imageUrl)
             viewController.modalPresentationStyle = .fullScreen
             viewController.modalTransitionStyle = .crossDissolve
             self?.present(viewController, animated: true)
         }
+
         return cell
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -77,7 +77,7 @@ extension LetterImageViewController: LetterImageViewDelegate {
     }
 
     private func uploadImage(for image: UIImage?, completionHandler: @escaping ((Result<(title: String, message: String), LetterImageError>) -> ())) {
-        guard let image = image else { completionHandler(.failure(.invalidImage)); return }
+        guard let image else { completionHandler(.failure(.invalidImage)); return }
 
         PHPhotoLibrary.shared().performChanges({
             PHAssetChangeRequest.creationRequestForAsset(from: image)

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -12,11 +12,16 @@ final class LetterImageViewController: BaseViewController {
 
     // MARK: - ui component
 
+    private let letterImageView: LetterImageView = LetterImageView()
+
+    // MARK: - property
+
+    private let imageUrl: String
 
     // MARK: - init
 
-    init(image: UIImage) {
-        self.imageView.image = image
+    init(imageUrl: String) {
+        self.imageUrl = imageUrl
         super.init()
     }
 
@@ -24,11 +29,14 @@ final class LetterImageViewController: BaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        print("\(#file) is dead")
+    // MARK: - life cycle
+
+    override func loadView() {
+        self.view = letterImageView
     }
 }
 
+// MARK: - LetterImageViewDelegate
 extension LetterImageViewController: LetterImageViewDelegate {
     func downloadImageAsset(_ imageAsset: UIImage?) {
         // MARK: - Error에 대한 처리 필요..

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -5,45 +5,12 @@
 //  Created by Mingwan Choi on 2022/09/18.
 //
 
-import Photos
 import UIKit
 
-import SnapKit
-
 final class LetterImageViewController: BaseViewController {
-    
+
     // MARK: - ui component
-    
-    private lazy var closeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(ImageLiterals.btnXmark, for: .normal)
-        button.tintColor = .grey001
-        button.addTarget(self, action: #selector(self.didTapCloseButton), for: .touchUpInside)
-        return button
-    }()
-    private lazy var scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.frame = view.bounds
-        scrollView.delegate = self
-        scrollView.zoomScale = 1.0
-        scrollView.minimumZoomScale = 1.0
-        scrollView.maximumZoomScale = 3.0
-        scrollView.contentInsetAdjustmentBehavior = .never
-        scrollView.showsVerticalScrollIndicator = false
-        scrollView.showsHorizontalScrollIndicator = false
-        return scrollView
-    }()
-    private let imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.isUserInteractionEnabled = true
-        return imageView
-    }()
-    private let downloadButton: UIButton = {
-        let button = UIButton()
-        button.setImage(ImageLiterals.icSave, for: .normal)
-        return button
-    }()
+
 
     // MARK: - init
 
@@ -58,108 +25,5 @@ final class LetterImageViewController: BaseViewController {
 
     deinit {
         print("\(#file) is dead")
-    }
-    
-    // MARK: - override
-    
-    override func setupLayout() {
-        self.view.addSubview(self.scrollView)
-        self.scrollView.addSubview(self.imageView)
-
-        self.view.addSubview(self.closeButton)
-        self.closeButton.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).inset(23)
-            $0.leading.equalTo(self.view.safeAreaLayoutGuide).inset(17)
-            $0.width.height.equalTo(44)
-        }
-        
-        self.view.addSubview(self.downloadButton)
-        self.downloadButton.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide).inset(23)
-            $0.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(17)
-        }
-    }
-    
-    override func configureUI() {
-        self.setupImageView()
-        self.setImagePinchGesture()
-        self.setupButtonAction()
-    }
-    
-    private func setupImageView() {
-        self.imageView.frame = self.scrollView.bounds
-        self.imageView.contentMode = .scaleAspectFit
-    }
-    
-    private func setImagePinchGesture() {
-        let pinch = UIPinchGestureRecognizer(target: self, action: #selector(self.didPinchImage(_:)))
-        self.view.addGestureRecognizer(pinch)
-    }
-    
-    private func setupButtonAction() {
-        let downloadAction = UIAction { [weak self] _ in
-            guard let image = self?.imageView.image else {
-                self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
-                                message: TextLiteral.letterImageViewControllerErrorMessage)
-                return
-            }
-            
-            PHPhotoLibrary.shared().performChanges({
-                PHAssetChangeRequest.creationRequestForAsset(from: image)
-            }) { (success, error) in
-                DispatchQueue.main.async {
-                    if success {
-                        self?.makeAlert(title: TextLiteral.letterImageViewControllerSuccessTitle,
-                                        message: TextLiteral.letterImageViewControllerSuccessMessage)
-                    } else if let error = error {
-                        Logger.debugDescription(error)
-                        self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
-                                        message: TextLiteral.letterImageViewControllerErrorMessage)
-                    }
-                }
-            }
-        }
-        self.downloadButton.addAction(downloadAction, for: .touchUpInside)
-    }
-    
-    // MARK: - selector
-    
-    @objc
-    private func didTapCloseButton() {
-        self.dismiss(animated: true)
-    }
-    
-    @objc
-    private func didPinchImage(_ pinch: UIPinchGestureRecognizer) {
-        self.imageView.transform = self.imageView.transform.scaledBy(x: pinch.scale, y: pinch.scale)
-        pinch.scale = 1
-    }
-}
-
-extension LetterImageViewController: UIScrollViewDelegate {
-    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-         return self.imageView
-     }
-    
-    func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        if scrollView.zoomScale > 1 {
-            guard let image = self.imageView.image else { return }
-            guard let zoomView = self.viewForZooming(in: scrollView) else { return }
-            
-            let widthRatio = zoomView.frame.width / image.size.width
-            let heightRatio = zoomView.frame.height / image.size.height
-            let ratio = widthRatio < heightRatio ? widthRatio : heightRatio
-            
-            let newWidth = image.size.width * ratio
-            let newHeight = image.size.height * ratio
-            
-            let left = 0.5 * (newWidth * scrollView.zoomScale > zoomView.frame.width ?
-                              (newWidth - zoomView.frame.width) : (scrollView.frame.width - scrollView.contentSize.width))
-            let top = 0.5 * (newHeight * scrollView.zoomScale > zoomView.frame.height ? (newHeight - zoomView.frame.height) : (scrollView.frame.height - scrollView.contentSize.height))
-            
-            scrollView.contentInset = UIEdgeInsets(top: top.rounded(), left: left.rounded(), bottom: top.rounded(), right: left.rounded())
-        } else {
-            scrollView.contentInset = .zero
-        }
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -32,7 +32,23 @@ final class LetterImageViewController: BaseViewController {
     // MARK: - life cycle
 
     override func loadView() {
-        self.view = letterImageView
+        self.view = self.letterImageView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureImage()
+        self.configureDelegation()
+    }
+
+    // MARK: - func
+
+    private func configureImage() {
+        self.letterImageView.configureImage(self.imageUrl)
+    }
+
+    private func configureDelegation() {
+        self.letterImageView.configureDelegate(self)
     }
 }
 

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -55,6 +55,6 @@ extension LetterImageViewController: LetterImageViewDelegate {
     }
 
     func closeButtonTapped() {
-        <#code#>
+        self.dismiss(animated: true)
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -12,7 +12,7 @@ final class LetterImageViewController: BaseViewController {
 
     // MARK: - ui component
 
-    private let letterImageView: LetterImageView = LetterImageView()
+    private lazy var letterImageView: LetterImageView = LetterImageView()
 
     // MARK: - property
 
@@ -37,13 +37,18 @@ final class LetterImageViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configureImage()
         self.configureDelegation()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.configureImageView()
     }
 
     // MARK: - func
 
-    private func configureImage() {
+    private func configureImageView() {
+        self.letterImageView.configureImageFrame()
         self.letterImageView.configureImage(self.imageUrl)
     }
 

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -59,6 +59,10 @@ final class LetterImageViewController: BaseViewController {
 
 // MARK: - LetterImageViewDelegate
 extension LetterImageViewController: LetterImageViewDelegate {
+    func closeButtonTapped() {
+        self.dismiss(animated: true)
+    }
+    
     func downloadImageAsset(_ imageAsset: UIImage?) {
         // MARK: - Error에 대한 처리 필요..
         guard let imageAsset = imageAsset else {
@@ -81,9 +85,5 @@ extension LetterImageViewController: LetterImageViewDelegate {
                 }
             }
         }
-    }
-
-    func closeButtonTapped() {
-        self.dismiss(animated: true)
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterImageViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterImageViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Mingwan Choi on 2022/09/18.
 //
 
+import Photos
 import UIKit
 
 final class LetterImageViewController: BaseViewController {
@@ -25,5 +26,35 @@ final class LetterImageViewController: BaseViewController {
 
     deinit {
         print("\(#file) is dead")
+    }
+}
+
+extension LetterImageViewController: LetterImageViewDelegate {
+    func downloadImageAsset(_ imageAsset: UIImage?) {
+        // MARK: - Error에 대한 처리 필요..
+        guard let imageAsset = imageAsset else {
+            self.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
+                           message: TextLiteral.letterImageViewControllerErrorMessage)
+            return
+        }
+
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.creationRequestForAsset(from: imageAsset)
+        }) { (success, error) in
+            DispatchQueue.main.async {
+                if success {
+                    self.makeAlert(title: TextLiteral.letterImageViewControllerSuccessTitle,
+                                   message: TextLiteral.letterImageViewControllerSuccessMessage)
+                } else if let error = error {
+                    Logger.debugDescription(error)
+                    self.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
+                                   message: TextLiteral.letterImageViewControllerErrorMessage)
+                }
+            }
+        }
+    }
+
+    func closeButtonTapped() {
+        <#code#>
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -335,8 +335,8 @@ extension LetterViewController: UICollectionViewDataSource {
             self?.sendReportMail(userNickname: UserDefaultStorage.nickname ?? "",
                                  content: self?.letterList[indexPath.item].content ?? "글 내용 없음")
         }
-        cell.didTappedImage = { [weak self] image in
-            let viewController = LetterImageViewController(image: image)
+        cell.didTappedImage = { [weak self] _ in
+            let viewController = LetterImageViewController(imageUrl: (self?.letterList[indexPath.item].imageUrl)!)
             viewController.modalPresentationStyle = .fullScreen
             viewController.modalTransitionStyle = .crossDissolve
             self?.present(viewController, animated: true)

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -336,7 +336,8 @@ extension LetterViewController: UICollectionViewDataSource {
                                  content: self?.letterList[indexPath.item].content ?? "글 내용 없음")
         }
         cell.didTappedImage = { [weak self] _ in
-            let viewController = LetterImageViewController(imageUrl: (self?.letterList[indexPath.item].imageUrl)!)
+            guard let imageUrl = self?.letterList[indexPath.item].imageUrl else { return }
+            let viewController = LetterImageViewController(imageUrl: imageUrl)
             viewController.modalPresentationStyle = .fullScreen
             viewController.modalTransitionStyle = .crossDissolve
             self?.present(viewController, animated: true)

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -134,24 +134,29 @@ extension LetterImageView: UIScrollViewDelegate {
      }
 
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        if scrollView.zoomScale > 1 {
-            guard let image = self.imageView.image else { return }
-            guard let zoomView = self.viewForZooming(in: scrollView) else { return }
+        let zoomScale = scrollView.zoomScale
+        let contentInset = self.scrollViewDidChangeContentInsets(scrollView, with: zoomScale)
+        scrollView.contentInset = contentInset
+    }
 
-            let widthRatio = zoomView.frame.width / image.size.width
-            let heightRatio = zoomView.frame.height / image.size.height
-            let ratio = widthRatio < heightRatio ? widthRatio : heightRatio
+    private func scrollViewDidChangeContentInsets(_ scrollView: UIScrollView, with zoomScale: CGFloat) -> UIEdgeInsets {
+        guard zoomScale > 1 else { return .zero }
+        guard let image = self.imageView.image else { return .zero }
+        guard let zoomView = self.viewForZooming(in: scrollView) else { return .zero }
 
-            let newWidth = image.size.width * ratio
-            let newHeight = image.size.height * ratio
+        let widthRatio = zoomView.frame.width / image.size.width
+        let heightRatio = zoomView.frame.height / image.size.height
+        let ratio = widthRatio < heightRatio ? widthRatio : heightRatio
+        let newWidth = image.size.width * ratio
+        let newHeight = image.size.height * ratio
 
-            let left = 0.5 * (newWidth * scrollView.zoomScale > zoomView.frame.width ?
-                              (newWidth - zoomView.frame.width) : (scrollView.frame.width - scrollView.contentSize.width))
-            let top = 0.5 * (newHeight * scrollView.zoomScale > zoomView.frame.height ? (newHeight - zoomView.frame.height) : (scrollView.frame.height - scrollView.contentSize.height))
+        let horizontalInset = 0.5 * (newWidth * scrollView.zoomScale > zoomView.frame.width ?
+                          (newWidth - zoomView.frame.width) : (scrollView.frame.width - scrollView.contentSize.width))
+        let verticalInset = 0.5 * (newHeight * scrollView.zoomScale > zoomView.frame.height ? (newHeight - zoomView.frame.height) : (scrollView.frame.height - scrollView.contentSize.height))
 
-            scrollView.contentInset = UIEdgeInsets(top: top.rounded(), left: left.rounded(), bottom: top.rounded(), right: left.rounded())
-        } else {
-            scrollView.contentInset = .zero
-        }
+        return UIEdgeInsets(top: horizontalInset.rounded(),
+                            left: verticalInset.rounded(),
+                            bottom: horizontalInset.rounded(),
+                            right: verticalInset.rounded())
     }
 }

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -107,8 +107,8 @@ final class LetterImageView: UIView {
         self.addGestureRecognizer(pinch)
     }
 
-    func configureImage(_ image: UIImage) {
-        self.imageView.image = image
+    func configureImage(_ imageUrl: String) {
+        self.imageView.loadImageUrl(imageUrl)
     }
 
     func configureDelegate(_ delegate: LetterImageViewDelegate) {

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -5,7 +5,6 @@
 //  Created by SHIN YOON AH on 2023/02/20.
 //
 
-import Photos
 import UIKit
 
 import SnapKit

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -154,9 +154,9 @@ extension LetterImageView: UIScrollViewDelegate {
                           (newWidth - zoomView.frame.width) : (scrollView.frame.width - scrollView.contentSize.width))
         let verticalInset = 0.5 * (newHeight * scrollView.zoomScale > zoomView.frame.height ? (newHeight - zoomView.frame.height) : (scrollView.frame.height - scrollView.contentSize.height))
 
-        return UIEdgeInsets(top: horizontalInset.rounded(),
-                            left: verticalInset.rounded(),
-                            bottom: horizontalInset.rounded(),
-                            right: verticalInset.rounded())
+        return UIEdgeInsets(top: verticalInset.rounded(),
+                            left: horizontalInset.rounded(),
+                            bottom: verticalInset.rounded(),
+                            right: horizontalInset.rounded())
     }
 }

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -1,0 +1,156 @@
+//
+//  LetterImageView.swift
+//  Manito
+//
+//  Created by SHIN YOON AH on 2023/02/20.
+//
+
+import Photos
+import UIKit
+
+import SnapKit
+
+final class LetterImageView: UIView {
+
+    // MARK: - ui component
+
+    private let closeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(ImageLiterals.btnXmark, for: .normal)
+        button.tintColor = .grey001
+        return button
+    }()
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.frame = self.bounds
+        scrollView.delegate = self
+        scrollView.zoomScale = 1.0
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 3.0
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        return scrollView
+    }()
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = true
+        imageView.frame = self.scrollView.bounds
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    private let downloadButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.icSave, for: .normal)
+        return button
+    }()
+
+    // MARK: - init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLayout()
+        self.setupAction()
+        self.setupImagePinchGesture()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - func
+
+    private func setupLayout() {
+        self.addSubview(self.scrollView)
+        self.scrollView.addSubview(self.imageView)
+
+        self.addSubview(self.closeButton)
+        self.closeButton.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).inset(23)
+            $0.leading.equalTo(self.safeAreaLayoutGuide).inset(17)
+            $0.width.height.equalTo(44)
+        }
+
+        self.addSubview(self.downloadButton)
+        self.downloadButton.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).inset(23)
+            $0.trailing.equalTo(self.safeAreaLayoutGuide).inset(17)
+        }
+    }
+
+    private func setupImagePinchGesture() {
+        let pinch = UIPinchGestureRecognizer(target: self, action: #selector(self.didPinchImage(_:)))
+        self.addGestureRecognizer(pinch)
+    }
+
+    private func setupAction() {
+        let downloadAction = UIAction { [weak self] _ in
+            guard let image = self?.imageView.image else {
+                self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
+                                message: TextLiteral.letterImageViewControllerErrorMessage)
+                return
+            }
+
+            PHPhotoLibrary.shared().performChanges({
+                PHAssetChangeRequest.creationRequestForAsset(from: image)
+            }) { (success, error) in
+                DispatchQueue.main.async {
+                    if success {
+                        self?.makeAlert(title: TextLiteral.letterImageViewControllerSuccessTitle,
+                                        message: TextLiteral.letterImageViewControllerSuccessMessage)
+                    } else if let error = error {
+                        Logger.debugDescription(error)
+                        self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
+                                        message: TextLiteral.letterImageViewControllerErrorMessage)
+                    }
+                }
+            }
+        }
+        self.downloadButton.addAction(downloadAction, for: .touchUpInside)
+        button.addTarget(self, action: #selector(self.didTapCloseButton), for: .touchUpInside)
+    }
+
+    // MARK: - selector
+
+    @objc
+    private func didTapCloseButton() {
+        self.dismiss(animated: true)
+    }
+
+    @objc
+    private func didPinchImage(_ pinch: UIPinchGestureRecognizer) {
+        self.imageView.transform = self.imageView.transform.scaledBy(x: pinch.scale, y: pinch.scale)
+        pinch.scale = 1
+    }
+}
+
+
+extension LetterImageView: UIScrollViewDelegate {
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+         return self.imageView
+     }
+
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        if scrollView.zoomScale > 1 {
+            guard let image = self.imageView.image else { return }
+            guard let zoomView = self.viewForZooming(in: scrollView) else { return }
+
+            let widthRatio = zoomView.frame.width / image.size.width
+            let heightRatio = zoomView.frame.height / image.size.height
+            let ratio = widthRatio < heightRatio ? widthRatio : heightRatio
+
+            let newWidth = image.size.width * ratio
+            let newHeight = image.size.height * ratio
+
+            let left = 0.5 * (newWidth * scrollView.zoomScale > zoomView.frame.width ?
+                              (newWidth - zoomView.frame.width) : (scrollView.frame.width - scrollView.contentSize.width))
+            let top = 0.5 * (newHeight * scrollView.zoomScale > zoomView.frame.height ? (newHeight - zoomView.frame.height) : (scrollView.frame.height - scrollView.contentSize.height))
+
+            scrollView.contentInset = UIEdgeInsets(top: top.rounded(), left: left.rounded(), bottom: top.rounded(), right: left.rounded())
+        } else {
+            scrollView.contentInset = .zero
+        }
+    }
+}

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -10,6 +10,11 @@ import UIKit
 
 import SnapKit
 
+protocol LetterImageViewDelegate: AnyObject {
+    func downloadImageAsset(_ imageAsset: UIImage?)
+    func closeButtonTapped()
+}
+
 final class LetterImageView: UIView {
 
     // MARK: - ui component
@@ -45,6 +50,10 @@ final class LetterImageView: UIView {
         button.setImage(ImageLiterals.icSave, for: .normal)
         return button
     }()
+
+    // MARK: - property
+
+    private weak var delegate: LetterImageViewDelegate?
 
     // MARK: - init
 
@@ -85,30 +94,17 @@ final class LetterImageView: UIView {
         self.addGestureRecognizer(pinch)
     }
 
+    func configureDelegate(_ delegate: LetterImageViewDelegate) {
+        self.delegate = delegate
+    }
+
     private func setupAction() {
         let downloadAction = UIAction { [weak self] _ in
-            guard let image = self?.imageView.image else {
-                self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
-                                message: TextLiteral.letterImageViewControllerErrorMessage)
-                return
-            }
-
-            PHPhotoLibrary.shared().performChanges({
-                PHAssetChangeRequest.creationRequestForAsset(from: image)
-            }) { (success, error) in
-                DispatchQueue.main.async {
-                    if success {
-                        self?.makeAlert(title: TextLiteral.letterImageViewControllerSuccessTitle,
-                                        message: TextLiteral.letterImageViewControllerSuccessMessage)
-                    } else if let error = error {
-                        Logger.debugDescription(error)
-                        self?.makeAlert(title: TextLiteral.letterImageViewControllerErrorTitle,
-                                        message: TextLiteral.letterImageViewControllerErrorMessage)
-                    }
-                }
-            }
+            let downloadImage = self?.imageView.image
+            self?.delegate?.downloadImageAsset(downloadImage)
         }
         self.downloadButton.addAction(downloadAction, for: .touchUpInside)
+        
         button.addTarget(self, action: #selector(self.didTapCloseButton), for: .touchUpInside)
     }
 

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -19,15 +19,8 @@ final class LetterImageView: UIView {
 
     // MARK: - ui component
 
-    private let closeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(ImageLiterals.btnXmark, for: .normal)
-        button.tintColor = .grey001
-        return button
-    }()
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.frame = self.bounds
         scrollView.delegate = self
         scrollView.zoomScale = 1.0
         scrollView.minimumZoomScale = 1.0
@@ -37,11 +30,16 @@ final class LetterImageView: UIView {
         scrollView.showsHorizontalScrollIndicator = false
         return scrollView
     }()
-    private lazy var imageView: UIImageView = {
+    private let closeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(ImageLiterals.btnXmark, for: .normal)
+        button.tintColor = .grey001
+        return button
+    }()
+    private let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.isUserInteractionEnabled = true
-        imageView.frame = self.scrollView.bounds
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
@@ -105,6 +103,11 @@ final class LetterImageView: UIView {
     private func setupImagePinchGesture() {
         let pinch = UIPinchGestureRecognizer(target: self, action: #selector(self.didPinchImage(_:)))
         self.addGestureRecognizer(pinch)
+    }
+
+    func configureImageFrame() {
+        self.scrollView.frame = self.bounds
+        self.imageView.frame = self.scrollView.bounds
     }
 
     func configureImage(_ imageUrl: String) {

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -89,15 +89,6 @@ final class LetterImageView: UIView {
         }
     }
 
-    private func setupImagePinchGesture() {
-        let pinch = UIPinchGestureRecognizer(target: self, action: #selector(self.didPinchImage(_:)))
-        self.addGestureRecognizer(pinch)
-    }
-
-    func configureDelegate(_ delegate: LetterImageViewDelegate) {
-        self.delegate = delegate
-    }
-
     private func setupAction() {
         let downloadAction = UIAction { [weak self] _ in
             let downloadImage = self?.imageView.image
@@ -109,6 +100,19 @@ final class LetterImageView: UIView {
             self?.delegate?.closeButtonTapped()
         }
         self.closeButton.addAction(closeAction, for: .touchUpInside)
+    }
+
+    private func setupImagePinchGesture() {
+        let pinch = UIPinchGestureRecognizer(target: self, action: #selector(self.didPinchImage(_:)))
+        self.addGestureRecognizer(pinch)
+    }
+
+    func configureImage(_ image: UIImage) {
+        self.imageView.image = image
+    }
+
+    func configureDelegate(_ delegate: LetterImageViewDelegate) {
+        self.delegate = delegate
     }
 
     // MARK: - selector

--- a/Manito/Manito/Screens/Letter/View/LetterImageView.swift
+++ b/Manito/Manito/Screens/Letter/View/LetterImageView.swift
@@ -104,16 +104,14 @@ final class LetterImageView: UIView {
             self?.delegate?.downloadImageAsset(downloadImage)
         }
         self.downloadButton.addAction(downloadAction, for: .touchUpInside)
-        
-        button.addTarget(self, action: #selector(self.didTapCloseButton), for: .touchUpInside)
+
+        let closeAction = UIAction { [weak self] _ in
+            self?.delegate?.closeButtonTapped()
+        }
+        self.closeButton.addAction(closeAction, for: .touchUpInside)
     }
 
     // MARK: - selector
-
-    @objc
-    private func didTapCloseButton() {
-        self.dismiss(animated: true)
-    }
 
     @objc
     private func didPinchImage(_ pinch: UIPinchGestureRecognizer) {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
LetterImageViewController는 서버 연결이 따로 없는 UIViewController입니다. Server API와의 연결이 없기 때문에 분리할 Model 관련 메소드나 변수도 없어서 View를 분리해봤습니다.
*Photo 라이브러리를 사용해서 사진을 저장하는 경우같은 Usecase가 나타나긴 해서 후에 이 부분을 따로 ViewModel로 뺄 수 있지 않을까 싶긴 한데, MVVM에 대한 이해도를 더 높이고 나서 생각해보겠습니다.

<br>

### ☑️ 분리 기준
<img width="963" alt="스크린샷 2023-02-21 오후 8 38 12" src="https://user-images.githubusercontent.com/55099365/220335022-cf4ef0e3-19d2-4109-9c3c-9e06d4ed4fa7.png">

**⓵ UI Component를 UIView 내부로 넣었습니다.**
UI Component와 UI Component 관련 메소드들을 UIView 내부로 넣었습니다. UIView는 UIViewController의 view로 설정을 했습니다.
```swift
    override func loadView() {
        self.view = self.letterImageView
    }
```
**⓶ UIAction에 대한 부분을 Delegate Pattern를 사용해서 UIViewController가 대신 하도록 구현했습니다.**
UIAction 내부에서 View 이외의 값을 변경해야 한다거나(서버 연결, 데이터 변경, 다른 뷰 변경), UIViewController에서 Action를 도와줘야 할 시(UIViewController에서 만들어서 사용해야하는 Function) Protocol로 해당 메서드들을 만들고 UIViewController에서 이를 conform해서 사용하도록 구현했습니다.
```swift
protocol LetterImageViewDelegate: AnyObject {
    func downloadImageAsset(_ imageAsset: UIImage?)
    func closeButtonTapped()
}

extension LetterImageViewController: LetterImageViewDelegate {
    func closeButtonTapped() {
        self.dismiss(animated: true)
    }
    
    func downloadImageAsset(_ imageAsset: UIImage?) {
        self.uploadImage(for: imageAsset) { [weak self] result in ...
        }
    }
}
```

**⓷ Configuration Setting** 
UIView 내부에 있는 UI Component의 기본적인 세팅을 할 때 UIViewController에서 받은 값을 사용해야 한다면 internal function를 사용해서 값을 받도록 했습니다.
```swift
    func configureImage(_ imageUrl: String) {
        self.imageView.loadImageUrl(imageUrl)
    }
```

<br>

### ☑️ UIView extension에 대한 고민
UIViewController에 있는 UI Component들을 UIView로 옮기면서 가장 고민이 되었던 부분은 extension에서 conform받은 delegate protocol를 어디다가 두느냐 였습니다. 현재 `UIScrollViewDelegate`는 UIView 내부에 위치합니다. 

**_왜인가요?_**
처음에는 UIViewController에 뺄 생각도 했었습니다. 하지만 UIView 내부에 계속 위치를 시킨 이유는 굳이 UIViewController로 보낼 필요가 없다는 점이었습니다. UIViewController에서만 사용할 수 있는 변수나 메소드를 사용해야하는 상황도 아니었고, UIViewController로 내보냈을 때 오히려 안좋다는 판단이 들어서 UIView에 넣어뒀습니다.

제가 UIView에서 delegate를 하게 된 이유는 이러합니다 :
```
1. UIView에서 internal하게 ScrollView, UIImageView를 선언해주어야 한다.
2. UIView에서 UIViewController없이도 충분히 구현할 수 있는데, 굳이 분리를 시킨 느낌이다.
3. Controller는 결국 UIView와 Model 사이에 연결을 해주는 다리 역할을 해주는데, ScrollView 내부에서 진행하는 일은 zoom 기능이기 때문에 굳이 Controller에서 해주지 않아도 된다.
```

LetterImageViewController 분리 작업을 하면서 가장 신경썼던 부분이 Controller는 View와 Model 사이 연결의 역할만 해야한다는 점이었습니다. 최대한 그 부분을 해치지 않으면서 분리를 하려고 했습니다. 그렇게 되었는지는 잘 모르겠네요.. 제 3자의 날카로운 의견이 필요합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

주요한 작업들은 이러합니다.
1. LetterImageViewController 내부에 있는 UI Component를 LetterImageView로 분리
2. LetterImageViewDelegate를 생성해서 UIViewController로 위임
3. LetterImageViewController에서 LetterImageView가 보이도록 연결
4. 뷰 에러 핸들링 진행
5. LetterImageViewController, LetterImageView 내부 함수 정리


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

제가 MVC에 대해서 잘 이해하고 분리를 한 건지는 모르겠습니다. 최대한 제가 생각하는 MVC 안에서 분리를 해보려고 했으니.. 다양한 의견 제시 부탁드립니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://user-images.githubusercontent.com/55099365/220349712-407a5d2a-b11b-499e-9ece-ed4fb506ac79.mp4

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #381

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 다양한 프로젝트 코드들을 참고해서 뷰를 분리했습니다.
