### PR TITLE
[FEAT] 쪽지가 전송되는 동안은 보내기 버튼이 비활성화 되도록 구현했습니다.

### DIFF
--- a/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
@@ -121,6 +121,7 @@ extension CreateLetterViewController: CreateLetterViewDelegate {
                     self?.succeedInSendingLetter?()
                     self?.dismiss(animated: true)
                 case .failure:
+                    self?.createLetterView.sending = false
                     self?.makeAlert(title: TextLiteral.createLetterViewControllerErrorTitle,
                                     message: TextLiteral.createLetterViewControllerErrorMessage)
                 }

--- a/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/CreateLetterViewController.swift
@@ -114,6 +114,7 @@ extension CreateLetterViewController: CreateLetterViewDelegate {
         let jpegData = image?.jpegData(compressionQuality: 0.3)
         let letterDTO = LetterDTO(manitteeId: self.manitteeId, messageContent: content)
 
+        self.createLetterView.sending = true
         self.dispatchLetter(with: letterDTO, jpegData) { [weak self] response in
             DispatchQueue.main.async {
                 switch response {

--- a/Manito/Manito/Screens/Letter/View/CreateLetterView.swift
+++ b/Manito/Manito/Screens/Letter/View/CreateLetterView.swift
@@ -63,6 +63,12 @@ final class CreateLetterView: UIView {
         }
     }
 
+    var sending: Bool = false {
+        willSet(isDisabled) {
+            self.sendButton.isEnabled = !isDisabled
+        }
+    }
+
     // MARK: - init
 
     override init(frame: CGRect) {
@@ -131,6 +137,7 @@ final class CreateLetterView: UIView {
             let image = self?.letterPhotoView.image
             let content = self?.letterTextView.text
             self?.delegate?.sendLetterToManittee(with: content, image)
+            self?.sending = true
         }
         self.sendButton.addAction(sendAction, for: .touchUpInside)
     }

--- a/Manito/Manito/Screens/Letter/View/CreateLetterView.swift
+++ b/Manito/Manito/Screens/Letter/View/CreateLetterView.swift
@@ -137,7 +137,6 @@ final class CreateLetterView: UIView {
             let image = self?.letterPhotoView.image
             let content = self?.letterTextView.text
             self?.delegate?.sendLetterToManittee(with: content, image)
-            self?.sending = true
         }
         self.sendButton.addAction(sendAction, for: .touchUpInside)
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
쪽지가 전송되는 동안 버튼이 비활성화되지 않아서 중복으로 보내기가 가능해집니다.
사용자가 불편함을 느낄 거 같아 이 부분을 수정했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### ☑️ CreateLetterView 내부에 Sending 변수를 추가했습니다.
Sending 변수는 보내는 중일때 true로 설정해주면 보내기 버튼의 isEnabled를 false로 설정해줍니다.
반대로 보내기가 실패하고 나서 Sending 변수를 false로 설정해주면 버튼의 isEnabled를 true로 설정해줍니다.

sendButton의 isEnabled에 직접적으로 true, false 값을 넣어주는게 과연 좋은걸까 라고 생각이 들어서 Sending이라는 변수를 따로 만들어서 사용했습니다. 


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

feature/406-sendbutton-disable 브랜치에서 빌드 돌려보시면 확인하실 수 있습니다. 
일요일까지 한다고 했는데 화요일에 했네요.. 늦은 PR 죄송합니다. 🙇‍♂️


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

* 쪽지를 보내고 연타를 하고 있었습니다. 버튼이 비활성화되어서 쪽지가 보내지지 않는걸 보실 수 있습니다.

  https://user-images.githubusercontent.com/55099365/224872245-f9198d11-37fc-4a30-a58e-066fbe47d6c1.mp4

* 쪽지 보내기가 실패했을 때 화면입니다. 실패했을 시에 버튼이 활성화되는걸 보실 수 있습니다.

  https://user-images.githubusercontent.com/55099365/224872362-979122bf-d8d8-4d98-ac84-979d0ef1bd5d.mp4




## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #406 