### PR TITLE
[REFACTOR] GuideView를 BaseViewController에서 분리했습니다.

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		B55BCEC628F5AFB200AF7E45 /* capsule.gif in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEC528F5AFB200AF7E45 /* capsule.gif */; };
 		B55BCEC828F5AFD500AF7E45 /* joystick.gif in Resources */ = {isa = PBXBuildFile; fileRef = B55BCEC728F5AFD500AF7E45 /* joystick.gif */; };
 		B5706BE129ADC20A0093D198 /* CreateLetterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5706BE029ADC20A0093D198 /* CreateLetterView.swift */; };
+		B5706BF629B9D4650093D198 /* GuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5706BF529B9D4650093D198 /* GuideView.swift */; };
 		B5E1F2AE285B2917006D880B /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E1F2AD285B2917006D880B /* Int+Extension.swift */; };
 		B5E1F2B0285EBB31006D880B /* OpenManittoPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E1F2AF285EBB31006D880B /* OpenManittoPopupViewController.swift */; };
 		B5E1F2B2285ECBDF006D880B /* SelectManittoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E1F2B1285ECBDF006D880B /* SelectManittoViewController.swift */; };
@@ -248,6 +249,7 @@
 		B55BCEC528F5AFB200AF7E45 /* capsule.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = capsule.gif; sourceTree = "<group>"; };
 		B55BCEC728F5AFD500AF7E45 /* joystick.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = joystick.gif; sourceTree = "<group>"; };
 		B5706BE029ADC20A0093D198 /* CreateLetterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateLetterView.swift; sourceTree = "<group>"; };
+		B5706BF529B9D4650093D198 /* GuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideView.swift; sourceTree = "<group>"; };
 		B5E1F2AD285B2917006D880B /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B5E1F2AF285EBB31006D880B /* OpenManittoPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenManittoPopupViewController.swift; sourceTree = "<group>"; };
 		B5E1F2B1285ECBDF006D880B /* SelectManittoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectManittoViewController.swift; sourceTree = "<group>"; };
@@ -704,6 +706,7 @@
 				B5F5253A2854ABF200614FF7 /* MainButton.swift */,
 				39FFE32728EEFFFE008442EE /* MoreButton.swift */,
 				7E7542B22923744300D725CB /* ToastPopupView.swift */,
+				B5706BF529B9D4650093D198 /* GuideView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -1189,6 +1192,7 @@
 				B5F525082851A05E00614FF7 /* InvitedCodeViewController.swift in Sources */,
 				B50B1AFD2856C3500080992C /* CreateLetterTextView.swift in Sources */,
 				D77224DF285DDAB7008B760B /* Notification+Extension.swift in Sources */,
+				B5706BF629B9D4650093D198 /* GuideView.swift in Sources */,
 				B50B1B41285B048A0080992C /* OpenManittoViewController.swift in Sources */,
 				CB5AE3E6285AB76800382EA3 /* PeopleInfoView.swift in Sources */,
 				39CD581F28C4C19100496E91 /* Memory.swift in Sources */,

--- a/Manito/Manito/Global/Base/BaseViewController.swift
+++ b/Manito/Manito/Global/Base/BaseViewController.swift
@@ -19,15 +19,6 @@ class BaseViewController: UIViewController {
         button.addAction(buttonAction, for: .touchUpInside)
         return button
     }()
-    lazy var guideButton = UIButton()
-    lazy var guideBoxImageView = UIImageView(image: ImageLiterals.imgGuideBox)
-    lazy var guideLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        label.font = .font(.regular, ofSize: 14)
-        label.contentMode = .center
-        return label
-    }()
     
     private let tokenService: TokenAPI = TokenAPI(apiService: APIService())
     
@@ -101,37 +92,6 @@ class BaseViewController: UIViewController {
         offsetView.bounds = offsetView.bounds.offsetBy(dx: offsetX, dy: offsetY)
         offsetView.addSubview(button)
         return offsetView
-    }
-    
-    func renderGuideArea() {
-        view.addSubview(guideBoxImageView)
-        guideBoxImageView.snp.makeConstraints {
-            $0.top.equalTo(guideButton.snp.bottom).offset(-10)
-            $0.trailing.equalTo(guideButton.snp.trailing).offset(-12)
-            $0.width.equalTo(270)
-            $0.height.equalTo(90)
-        }
-        
-        guideBoxImageView.addSubview(guideLabel)
-        guideLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(20)
-            $0.leading.trailing.equalToSuperview().inset(15)
-        }
-    }
-    
-    func setupGuideArea() {
-        let guideAction = UIAction { [weak self] _ in
-            self?.guideBoxImageView.isHidden.toggle()
-        }
-        guideButton.addAction(guideAction, for: .touchUpInside)
-        guideBoxImageView.isHidden = true
-    }
-    
-    func setupGuideText(title: String, text: String) {
-        guideLabel.text = text
-        guideLabel.addLabelSpacing()
-        guideLabel.textAlignment = .center
-        guideLabel.applyColor(to: title, with: .subOrange)
     }
     
     // MARK: - private func

--- a/Manito/Manito/Global/Literal/ImageLiteral.swift
+++ b/Manito/Manito/Global/Literal/ImageLiteral.swift
@@ -18,7 +18,7 @@ enum ImageLiterals {
     static var icInsta: UIImage { .load(name: "ic_insta")}
     static var icReport: UIImage { .load(name: "ic_report")}
     static var icMore: UIImage { .load(name: "ic_more")}
-    static var icLetterInfo: UIImage { .load(name: "ic_letterInfo")}
+    static var icLetterMissionInfo: UIImage { .load(name: "ic_letterInfo")}
     static var icMissionInfo: UIImage { .load(name: "ic_missionInfo")}
     static var icRight: UIImage { .load(name: "ic_right")}
     static var icSave: UIImage { .load(name: "ic_save")}

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -62,8 +62,7 @@ enum TextLiteral {
     
     // MARK: - MainViewController
     static let mainViewControllerMenuTitle: String = "참여중인 애니또"
-    static let mainViewControllerGuideTitle: String = "공통 미션이란?"
-    static let mainViewControllerGuideDescription: String = "공통 미션이란?\n마니또에 참여한 모두에게 \n수행하는 미션이에요. "
+    static let mainViewControllerGuideText: String = "공통 미션이란?\n마니또에 참여한 모두에게 \n수행하는 미션이에요. "
     static let mainViewControllerNewRoomAlert: String = "새로운 마니또 시작"
     static let mainViewControllerShowIdErrorAlertTitle: String = "해당 마니또 방의 정보를 불러오지 못했습니다."
     static let mainViewControllerShowIdErrorAlertMessage: String = "해당 마니또 방으로 이동할 수 없습니다."
@@ -119,8 +118,7 @@ enum TextLiteral {
     
     // MARK: - LetterViewController
     static let letterViewControllerTitle = "쪽지함"
-    static let letterViewControllerGuideTitle = "쪽지 쓰기는?"
-    static let letterViewControllerGuideText = "마니띠에게만 쓰기가 가능해요.\n마니또로부터는 확인만 할 수 있어요."
+    static let letterViewControllerGuideText = "쪽지 쓰기는?\n마니띠에게만 쓰기가 가능해요.\n마니또로부터는 확인만 할 수 있어요."
     static let letterViewControllerEmptyViewFrom = """
         쪽지함이 비었어요.
         곧 마니또가 쪽지를 보낼거에요!
@@ -145,8 +143,7 @@ enum TextLiteral {
     
     // MARK: - DetailIngViewController
     static let detailIngViewControllerManitoOpenButton: String = "마니또 공개"
-    static let detailIngViewControllerGuideTitle: String = "개별 미션이란?"
-    static let detailIngViewControllerText: String = "개별 미션이란?\n나의 마니띠에게\n수행하는 미션이에요."
+    static let detailIngViewControllerGuideText: String = "개별 미션이란?\n나의 마니띠에게\n수행하는 미션이에요."
     static let detailIngViewControllerDoneMissionText: String = "종료된 마니또예요"
     static let detailIngViewControllerDoneExitAlertTitle: String = "정말 방을 나가시겠습니까?"
     static let detailIngViewControllerDoneExitAlertAdminTitle: String = "정말 방을 삭제하시겠습니까?"

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -19,14 +19,14 @@ final class GuideView: UIView {
         var text: String {
             switch self {
             case .letter: return TextLiteral.letterViewControllerGuideText
-            case .main: return TextLiteral.mainViewControllerGuideDescription
-            case .detailing: return TextLiteral.detailIngViewControllerGuideTitle
+            case .main: return TextLiteral.mainViewControllerGuideText
+            case .detailing: return TextLiteral.detailIngViewControllerGuideText
             }
         }
 
         var image: UIImage {
             switch self {
-            case .letter: return ImageLiterals.icLetterInfo
+            case .letter: return ImageLiterals.icLetterMissionInfo
             default: return ImageLiterals.icMissionInfo
             }
         }

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -89,12 +89,26 @@ final class GuideView: UIView {
         self.guideLabel.applyColor(to: targetTitle, with: .subOrange)
     }
 
-    private func setupGuideButtonLayout() {
+    private func setupGuideViewLayout() {
         self.addSubview(self.guideButton)
         self.guideButton.snp.makeConstraints {
             $0.top.equalTo(self.snp.top)
             $0.trailing.equalTo(self.snp.trailing)
             $0.width.height.equalTo(44)
+        }
+
+        self.addSubview(self.guideBoxImageView)
+        self.guideBoxImageView.snp.makeConstraints {
+            $0.top.equalTo(self.guideButton.snp.bottom).offset(-10)
+            $0.trailing.equalTo(self.guideButton.snp.trailing).offset(-12)
+            $0.width.equalTo(270)
+            $0.height.equalTo(90)
+        }
+
+        self.guideBoxImageView.addSubview(self.guideLabel)
+        self.guideLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(15)
         }
     }
 
@@ -116,27 +130,11 @@ final class GuideView: UIView {
         }
     }
 
-    private func setupGuideBoxLayout() {
-        self.addSubview(self.guideBoxImageView)
-        self.guideBoxImageView.snp.makeConstraints {
-            $0.top.equalTo(self.guideButton.snp.bottom).offset(-10)
-            $0.trailing.equalTo(self.guideButton.snp.trailing).offset(-12)
-            $0.width.equalTo(270)
-            $0.height.equalTo(90)
-        }
-
-        self.guideBoxImageView.addSubview(self.guideLabel)
-        self.guideLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(20)
-            $0.leading.trailing.equalToSuperview().inset(15)
-        }
+    func addGuideView() {
+        self.setupGuideViewLayout()
     }
 
-    func setupDisappearedConfiguration() {
-        self.guideBoxImageView.isHidden = true
-    }
-
-    func addGuideViewToNavigationController(_ navigationController: UINavigationController) {
+    func addGuideView(in navigationController: UINavigationController) {
         self.setupGuideButtonLayoutInNavigationBar()
         self.setupGuideBoxLayout(in: navigationController)
 
@@ -151,6 +149,10 @@ final class GuideView: UIView {
         viewControllerTapGesture.cancelsTouchesInView = false
         navigationController.view.addGestureRecognizer(navigationControllerTapGesture)
         viewController.view.addGestureRecognizer(viewControllerTapGesture)
+    }
+
+    func setupDisappearedConfiguration() {
+        self.guideBoxImageView.isHidden = true
     }
 
     // MARK: - selector

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -44,14 +44,9 @@ final class GuideView: UIView {
         return label
     }()
 
-    // MARK: - property
-
-    private let type: GuideType
-
     // MARK: - init
 
     init(type: GuideType) {
-        self.type = type
         super.init(frame: .zero)
         self.setupGuideAction()
         self.configureUI(with: type)

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -128,6 +128,12 @@ final class GuideView: UIView {
                 $0.width.equalTo(270)
                 $0.height.equalTo(90)
             }
+
+            self.guideBoxImageView.addSubview(self.guideLabel)
+            self.guideLabel.snp.makeConstraints {
+                $0.top.equalToSuperview().inset(20)
+                $0.leading.trailing.equalToSuperview()
+            }
         }
     }
 
@@ -138,9 +144,11 @@ final class GuideView: UIView {
     func addGuideView(in navigationController: UINavigationController) {
         self.setupGuideButtonLayoutInNavigationBar()
         self.setupGuideBoxLayout(in: navigationController)
+    }
 
+    func addGuideButton(in navigationItem: UINavigationItem) {
         let guideButton = UIBarButtonItem(customView: self.guideButton)
-        navigationController.navigationItem.rightBarButtonItem = guideButton
+        navigationItem.rightBarButtonItem = guideButton
     }
 
     func hideGuideViewWhenTappedAround(in navigationController: UINavigationController, _ viewController: UIViewController) {

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -84,7 +84,7 @@ final class GuideView: UIView {
         self.guideLabel.applyColor(to: targetTitle, with: .subOrange)
     }
 
-    private func setupGuideViewLayout() {
+    func setupGuideViewLayout() {
         self.addSubview(self.guideButton)
         self.guideButton.snp.makeConstraints {
             $0.top.equalTo(self.snp.top)
@@ -108,7 +108,7 @@ final class GuideView: UIView {
         }
     }
 
-    private func setupGuideViewLayout(in navigationController: UINavigationController) {
+    func setupGuideViewLayout(in navigationController: UINavigationController) {
         if let view = navigationController.view {
             self.guideButton.snp.makeConstraints {
                 $0.width.height.equalTo(44)
@@ -128,14 +128,6 @@ final class GuideView: UIView {
                 $0.leading.trailing.equalToSuperview()
             }
         }
-    }
-
-    func addGuideView() {
-        self.setupGuideViewLayout()
-    }
-
-    func addGuideView(in navigationController: UINavigationController) {
-        self.setupGuideViewLayout(in: navigationController)
     }
 
     func addGuideButton(in navigationItem: UINavigationItem) {

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -101,6 +101,7 @@ final class GuideView: UIView {
         self.guideBoxImageView.snp.makeConstraints {
             $0.top.equalTo(self.guideButton.snp.bottom).offset(-10)
             $0.trailing.equalTo(self.guideButton.snp.trailing).offset(-12)
+            $0.leading.bottom.equalToSuperview()
             $0.width.equalTo(270)
             $0.height.equalTo(90)
         }
@@ -142,9 +143,9 @@ final class GuideView: UIView {
         navigationController.navigationItem.rightBarButtonItem = guideButton
     }
 
-    func hideGuideView(in navigationController: UINavigationController, _ viewController: UIViewController) {
-        let navigationControllerTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.dismissGuideView))
-        let viewControllerTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.dismissGuideView))
+    func hideGuideViewWhenTappedAround(in navigationController: UINavigationController, _ viewController: UIViewController) {
+        let navigationControllerTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.didTapAroundToHideGuideView))
+        let viewControllerTapGesture = UITapGestureRecognizer(target: self, action: #selector(self.didTapAroundToHideGuideView))
         navigationControllerTapGesture.cancelsTouchesInView = false
         viewControllerTapGesture.cancelsTouchesInView = false
         navigationController.view.addGestureRecognizer(navigationControllerTapGesture)
@@ -158,7 +159,7 @@ final class GuideView: UIView {
     // MARK: - selector
 
     @objc
-    private func dismissGuideView() {
+    func didTapAroundToHideGuideView() {
         if !self.guideButton.isTouchInside {
             self.setupDisappearedConfiguration()
         }

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -1,0 +1,81 @@
+//
+//  GuideView.swift
+//  Manito
+//
+//  Created by SHIN YOON AH on 2023/03/09.
+//
+
+import UIKit
+
+import SnapKit
+
+final class GuideView: UIView {
+
+    // MARK: - ui component
+
+    private let guideButton: UIButton = UIButton()
+    private let guideBoxImageView: UIImageView = UIImageView(image: ImageLiterals.imgGuideBox)
+    private let guideLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = .font(.regular, ofSize: 14)
+        label.contentMode = .center
+        return label
+    }()
+
+    // MARK: - init
+
+    init(content: String) {
+        super.init(frame: .zero)
+        self.setupLayout()
+        self.configureUI()
+        self.setupGuideAction()
+        self.configureGuideContent(to: content)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - func
+
+    private func setupLayout() {
+        self.addSubview(self.guideBoxImageView)
+        self.guideBoxImageView.snp.makeConstraints {
+            $0.top.equalTo(self.guideButton.snp.bottom).offset(-10)
+            $0.trailing.equalTo(self.guideButton.snp.trailing).offset(-12)
+            $0.width.equalTo(270)
+            $0.height.equalTo(90)
+        }
+
+        self.guideBoxImageView.addSubview(self.guideLabel)
+        self.guideLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(15)
+        }
+    }
+
+    private func configureUI() {
+        self.guideBoxImageView.isHidden = true
+    }
+
+    private func setupGuideAction() {
+        let guideAction = UIAction { [weak self] _ in
+            self?.guideBoxImageView.isHidden.toggle()
+        }
+        self.guideButton.addAction(guideAction, for: .touchUpInside)
+    }
+
+    private func configureGuideContent(to content: String) {
+        self.guideLabel.text = content
+        self.guideLabel.addLabelSpacing()
+        self.guideLabel.textAlignment = .center
+        self.applyColorToTargetContent(content)
+    }
+    
+    private func applyColorToTargetContent(_ content: String) {
+        guard let targetTitle = content.split(separator: "\n").map({ String($0) }).first else { return }
+        self.guideLabel.applyColor(to: targetTitle, with: .subOrange)
+    }
+}

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -13,17 +13,21 @@ final class GuideView: UIView {
 
     enum GuideType: String {
         case letter
+        case main
+        case detailing
 
         var text: String {
             switch self {
             case .letter: return TextLiteral.letterViewControllerGuideText
-            default: return ""
+            case .main: return TextLiteral.mainViewControllerGuideDescription
+            case .detailing: return TextLiteral.detailIngViewControllerGuideTitle
             }
         }
 
         var image: UIImage {
             switch self {
             case .letter: return ImageLiterals.icLetterInfo
+            default: return ImageLiterals.icMissionInfo
             }
         }
     }
@@ -88,8 +92,8 @@ final class GuideView: UIView {
     private func setupGuideButtonLayout() {
         self.addSubview(self.guideButton)
         self.guideButton.snp.makeConstraints {
-            $0.top.equalTo(self.snp.top).offset(30)
-            $0.trailing.equalTo(self.snp.trailing).inset(30)
+            $0.top.equalTo(self.snp.top)
+            $0.trailing.equalTo(self.snp.trailing)
             $0.width.height.equalTo(44)
         }
     }

--- a/Manito/Manito/Global/UIComponent/GuideView.swift
+++ b/Manito/Manito/Global/UIComponent/GuideView.swift
@@ -108,18 +108,16 @@ final class GuideView: UIView {
         }
     }
 
-    private func setupGuideButtonLayoutInNavigationBar() {
-        self.guideButton.snp.makeConstraints {
-            $0.width.height.equalTo(44)
-        }
-    }
+    private func setupGuideViewLayout(in navigationController: UINavigationController) {
+        if let view = navigationController.view {
+            self.guideButton.snp.makeConstraints {
+                $0.width.height.equalTo(44)
+            }
 
-    private func setupGuideBoxLayout(in navigationController: UINavigationController) {
-        if let navigationView = navigationController.view {
-            navigationView.addSubview(self.guideBoxImageView)
+            view.addSubview(self.guideBoxImageView)
             self.guideBoxImageView.snp.makeConstraints {
-                $0.top.equalTo(navigationView.safeAreaLayoutGuide.snp.top).inset(35)
-                $0.trailing.equalTo(navigationView.snp.trailing).inset(Size.leadingTrailingPadding + 8)
+                $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(35)
+                $0.trailing.equalTo(view.snp.trailing).inset(Size.leadingTrailingPadding + 8)
                 $0.width.equalTo(270)
                 $0.height.equalTo(90)
             }
@@ -137,8 +135,7 @@ final class GuideView: UIView {
     }
 
     func addGuideView(in navigationController: UINavigationController) {
-        self.setupGuideButtonLayoutInNavigationBar()
-        self.setupGuideBoxLayout(in: navigationController)
+        self.setupGuideViewLayout(in: navigationController)
     }
 
     func addGuideButton(in navigationItem: UINavigationItem) {

--- a/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailIngViewController.swift
@@ -110,12 +110,6 @@ class DetailIngViewController: BaseViewController {
         case .none: break
         }
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        setupGuideArea()
-        renderGuideArea()
-    }
 
     override func setupLayout() {
         view.addSubview(manitoOpenButton)
@@ -130,13 +124,6 @@ class DetailIngViewController: BaseViewController {
             $0.trailing.equalTo(manitteeIconView.snp.trailing)
             $0.leading.equalTo(manitteeIconView.snp.leading)
             $0.bottom.equalTo(manitteeIconView.snp.bottom)
-        }
-        
-        view.addSubview(guideButton)
-        guideButton.snp.makeConstraints {
-            $0.top.equalTo(missionBackgroundView.snp.top)
-            $0.trailing.equalTo(missionBackgroundView.snp.trailing)
-            $0.width.height.equalTo(44)
         }
         
         view.addSubview(badgeLabel)
@@ -163,12 +150,6 @@ class DetailIngViewController: BaseViewController {
         manitteeLabel.text = "\(UserDefaultStorage.nickname ?? "당신")의 마니띠"
         manitteeIconView.image = ImageLiterals.icManiTti
         listIconView.image = ImageLiterals.icList
-    }
-    
-    override func setupGuideArea() {
-        super.setupGuideArea()
-        guideButton.setImage(ImageLiterals.icMissionInfo, for: .normal)
-        setupGuideText(title: TextLiteral.detailIngViewControllerGuideTitle, text: TextLiteral.detailIngViewControllerText)
     }
     
     override func setupNavigationBar() {
@@ -480,13 +461,6 @@ class DetailIngViewController: BaseViewController {
                     self.isTappedManittee = false
                 }
             }
-        }
-    }
-    
-    @objc
-    override func endEditingView() {
-        if !guideButton.isTouchInside {
-            guideBoxImageView.isHidden = true
         }
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -217,6 +217,7 @@ final class DetailingCodebaseViewController: BaseViewController {
         button.showsMenuAsPrimaryAction = true
         return button
     }()
+    private let guideView: GuideView = GuideView(type: .detailing)
     
     // MARK: - init
     
@@ -385,14 +386,19 @@ final class DetailingCodebaseViewController: BaseViewController {
             $0.bottom.equalTo(manitteeIconView.snp.bottom)
         }
 
-        // TODO: - guideview layout
-
         view.addSubview(badgeLabel)
         badgeLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview().offset(35)
             $0.centerY.equalTo(letterBoxButton).offset(-10)
             $0.width.height.equalTo(30)
         }
+
+        self.view.addSubview(self.guideView)
+        self.guideView.snp.makeConstraints {
+            $0.top.equalTo(self.missionBackgroundView.snp.top)
+            $0.trailing.equalTo(self.missionBackgroundView.snp.trailing)
+        }
+        self.guideView.addGuideView()
     }
     
     override func setupNavigationBar() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -406,6 +406,10 @@ final class DetailingCodebaseViewController: BaseViewController {
         let rightItem = makeBarButtonItem(with: exitButton)
         navigationItem.rightBarButtonItem = rightItem
     }
+
+    override func endEditingView() {
+        self.guideView.didTapAroundToHideGuideView()
+    }
     
     // MARK: - func
     

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -235,12 +235,6 @@ final class DetailingCodebaseViewController: BaseViewController {
     
     // MARK: - life cycle
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        setupGuideArea()
-        renderGuideArea()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupLargeTitleToOriginal()
@@ -391,12 +385,7 @@ final class DetailingCodebaseViewController: BaseViewController {
             $0.bottom.equalTo(manitteeIconView.snp.bottom)
         }
 
-        view.addSubview(guideButton)
-        guideButton.snp.makeConstraints {
-            $0.top.equalTo(missionBackgroundView.snp.top)
-            $0.trailing.equalTo(missionBackgroundView.snp.trailing)
-            $0.width.height.equalTo(44)
-        }
+        // TODO: - guideview layout
 
         view.addSubview(badgeLabel)
         badgeLabel.snp.makeConstraints {
@@ -404,12 +393,6 @@ final class DetailingCodebaseViewController: BaseViewController {
             $0.centerY.equalTo(letterBoxButton).offset(-10)
             $0.width.height.equalTo(30)
         }
-    }
-    
-    override func setupGuideArea() {
-        super.setupGuideArea()
-        guideButton.setImage(ImageLiterals.icMissionInfo, for: .normal)
-        setupGuideText(title: TextLiteral.detailIngViewControllerGuideTitle, text: TextLiteral.detailIngViewControllerText)
     }
     
     override func setupNavigationBar() {
@@ -492,13 +475,6 @@ final class DetailingCodebaseViewController: BaseViewController {
     }
   
     // MARK: - selector
-    
-    @objc
-    override func endEditingView() {
-        if !guideButton.isTouchInside {
-            guideBoxImageView.isHidden = true
-        }
-    }
     
     @objc
     private func didTappedManittee() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -398,7 +398,7 @@ final class DetailingCodebaseViewController: BaseViewController {
             $0.top.equalTo(self.missionBackgroundView.snp.top)
             $0.trailing.equalTo(self.missionBackgroundView.snp.trailing)
         }
-        self.guideView.addGuideView()
+        self.guideView.setupGuideViewLayout()
     }
     
     override func setupNavigationBar() {

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -186,7 +186,7 @@ final class LetterViewController: BaseViewController {
 
     private func setupGuideViewInNavigationController() {
         if let navigationController {
-            self.guideView.addGuideView(in: navigationController)
+            self.guideView.setupGuideViewLayout(in: navigationController)
             self.guideView.hideGuideViewWhenTappedAround(in: navigationController, self)
         }
     }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -80,6 +80,7 @@ final class LetterViewController: BaseViewController {
         return label
     }()
     private lazy var sendLetterView: BottomOfSendLetterView = BottomOfSendLetterView()
+    private let guideView: GuideView = GuideView(type: .letter)
 
     // MARK: - property
     
@@ -126,7 +127,7 @@ final class LetterViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupButtonAction()
-        self.hideGuideViewWhenTappedAround()
+        self.setupGuideViewInNavigationController()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -135,8 +136,8 @@ final class LetterViewController: BaseViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        // TODO: - guide setupDisappearedConfiguration
-//        self.guideBoxImageView.isHidden = true
+        super.viewWillDisappear(animated)
+        self.guideView.setupDisappearedConfiguration()
     }
 
     // MARK: - override
@@ -164,15 +165,12 @@ final class LetterViewController: BaseViewController {
         super.configureUI()
         self.reloadCollectionView(with: self.letterState)
         self.setupEmptyLabel()
-        // TODO: - guide view configuration
-//        self.guideButton.setImage(ImageLiterals.icLetterInfo, for: .normal)
-//        self.setupGuideText(title: TextLiteral.letterViewControllerGuideTitle, text: TextLiteral.letterViewControllerGuideText)
     }
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        // TODO: - guideview navigationcontroller
         self.title = TextLiteral.letterViewControllerTitle
+        self.guideView.addGuideButton(in: self.navigationItem)
     }
 
     // MARK: - func
@@ -184,6 +182,13 @@ final class LetterViewController: BaseViewController {
     
     private func setupEmptyView() {
         self.emptyLabel.isHidden = !self.letterList.isEmpty
+    }
+
+    private func setupGuideViewInNavigationController() {
+        if let navigationController {
+            self.guideView.addGuideView(in: navigationController)
+            self.guideView.hideGuideViewWhenTappedAround(in: navigationController, self)
+        }
     }
     
     private func setupButtonAction() {
@@ -232,10 +237,6 @@ final class LetterViewController: BaseViewController {
         label.addLabelSpacing()
         label.sizeToFit()
         return label.frame.height
-    }
-
-    private func hideGuideViewWhenTappedAround() {
-        // TODO: - hideGuideView
     }
     
     private func setupEmptyLabel() {
@@ -359,6 +360,6 @@ extension LetterViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - UICollectionViewDelegate
 extension LetterViewController: UICollectionViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        // TODO: - setup disappeared configuration
+        self.guideView.setupDisappearedConfiguration()
     }
 }

--- a/Manito/Manito/Screens/Letter/LetterViewController.swift
+++ b/Manito/Manito/Screens/Letter/LetterViewController.swift
@@ -126,8 +126,6 @@ final class LetterViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupButtonAction()
-        self.setupGuideArea()
-        self.renderGuideArea()
         self.hideGuideViewWhenTappedAround()
     }
     
@@ -137,7 +135,8 @@ final class LetterViewController: BaseViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        self.guideBoxImageView.isHidden = true
+        // TODO: - guide setupDisappearedConfiguration
+//        self.guideBoxImageView.isHidden = true
     }
 
     // MARK: - override
@@ -146,11 +145,6 @@ final class LetterViewController: BaseViewController {
         self.view.addSubview(self.listCollectionView)
         self.listCollectionView.snp.makeConstraints {
             $0.edges.equalTo(self.view.safeAreaLayoutGuide)
-        }
-        
-        self.view.addSubview(self.guideButton)
-        self.guideButton.snp.makeConstraints {
-            $0.width.height.equalTo(44)
         }
 
         self.view.addSubview(self.emptyLabel)
@@ -170,38 +164,15 @@ final class LetterViewController: BaseViewController {
         super.configureUI()
         self.reloadCollectionView(with: self.letterState)
         self.setupEmptyLabel()
+        // TODO: - guide view configuration
+//        self.guideButton.setImage(ImageLiterals.icLetterInfo, for: .normal)
+//        self.setupGuideText(title: TextLiteral.letterViewControllerGuideTitle, text: TextLiteral.letterViewControllerGuideText)
     }
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
-
-        let guideButton = self.makeBarButtonItem(with: self.guideButton)
-        self.navigationItem.rightBarButtonItem = guideButton
+        // TODO: - guideview navigationcontroller
         self.title = TextLiteral.letterViewControllerTitle
-    }
-    
-    override func setupGuideArea() {
-        super.setupGuideArea()
-        self.guideButton.setImage(ImageLiterals.icLetterInfo, for: .normal)
-        self.setupGuideText(title: TextLiteral.letterViewControllerGuideTitle, text: TextLiteral.letterViewControllerGuideText)
-    }
-    
-    override func renderGuideArea() {
-        if let navigationView = self.navigationController?.view {
-            navigationView.addSubview(self.guideBoxImageView)
-            self.guideBoxImageView.snp.makeConstraints {
-                $0.top.equalTo(navigationView.safeAreaLayoutGuide.snp.top).inset(35)
-                $0.trailing.equalTo(navigationView.snp.trailing).inset(Size.leadingTrailingPadding + 8)
-                $0.width.equalTo(270)
-                $0.height.equalTo(90)
-            }
-        }
-        
-        self.guideBoxImageView.addSubview(self.guideLabel)
-        self.guideLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(20)
-            $0.leading.trailing.equalToSuperview().inset(15)
-        }
     }
 
     // MARK: - func
@@ -262,28 +233,14 @@ final class LetterViewController: BaseViewController {
         label.sizeToFit()
         return label.frame.height
     }
-    
+
     private func hideGuideViewWhenTappedAround() {
-        let navigationTap = UITapGestureRecognizer(target: self, action: #selector(self.dismissGuideView))
-        let viewTap = UITapGestureRecognizer(target: self, action: #selector(self.dismissGuideView))
-        navigationTap.cancelsTouchesInView = false
-        viewTap.cancelsTouchesInView = false
-        self.navigationController?.view.addGestureRecognizer(navigationTap)
-        self.view.addGestureRecognizer(viewTap)
+        // TODO: - hideGuideView
     }
     
     private func setupEmptyLabel() {
         self.emptyLabel.text = self.letterState.labelText
         self.emptyLabel.isHidden = true
-    }
-    
-    // MARK: - selector
-    
-    @objc
-    private func dismissGuideView() {
-        if !self.guideButton.isTouchInside {
-            self.guideBoxImageView.isHidden = true
-        }
     }
     
     // MARK: - network
@@ -402,6 +359,6 @@ extension LetterViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - UICollectionViewDelegate
 extension LetterViewController: UICollectionViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        self.guideBoxImageView.isHidden = true
+        // TODO: - setup disappeared configuration
     }
 }

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -166,12 +166,7 @@ final class MainViewController: BaseViewController {
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
-        self.view.addSubview(self.guideButton)
-        self.guideButton.snp.makeConstraints {
-            $0.top.equalTo(self.commonMissionView.snp.top).offset(30)
-            $0.trailing.equalTo(self.commonMissionView.snp.trailing).inset(30)
-            $0.width.height.equalTo(44)
-        }
+        // TODO: - guideview layout
     }
 
     override func setupNavigationBar() {
@@ -184,12 +179,6 @@ final class MainViewController: BaseViewController {
         self.navigationItem.largeTitleDisplayMode = .automatic
         self.navigationItem.leftBarButtonItem = appTitleView
         self.navigationItem.rightBarButtonItem = settingButtonView
-    }
-    
-    override func setupGuideArea() {
-        super.setupGuideArea()
-        self.guideButton.setImage(ImageLiterals.icMissionInfo, for: .normal)
-        self.setupGuideText(title: TextLiteral.mainViewControllerGuideTitle, text: TextLiteral.mainViewControllerGuideDescription)
     }
     
     // MARK: - func
@@ -296,15 +285,6 @@ final class MainViewController: BaseViewController {
     func showRoomIdErrorAlert() {
         self.makeAlert(title: TextLiteral.mainViewControllerShowIdErrorAlertTitle,
                        message: TextLiteral.mainViewControllerShowIdErrorAlertMessage)
-    }
-    
-    // MARK: - selector
-    
-    @objc
-    override func endEditingView() {
-        if !self.guideButton.isTouchInside {
-            self.guideBoxImageView.isHidden = true
-        }
     }
     
     // MARK: - network

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -89,6 +89,7 @@ final class MainViewController: BaseViewController {
     private let maCharacterImageView: GIFImageView = GIFImageView()
     private let niCharacterImageView: GIFImageView = GIFImageView()
     private let ttoCharacterImageView: GIFImageView = GIFImageView()
+    private let guideView: GuideView = GuideView(type: .main)
     
     // MARK: - property
     
@@ -166,7 +167,15 @@ final class MainViewController: BaseViewController {
             $0.leading.trailing.bottom.equalToSuperview()
         }
         
-        // TODO: - guideview layout
+        self.commonMissionView.addSubview(self.guideView)
+        self.guideView.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(30)
+        }
+        self.guideView.addGuideView()
+    }
+
+    override func endEditingView() {
+        self.guideView.didTapAroundToHideGuideView()
     }
 
     override func setupNavigationBar() {

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -174,10 +174,6 @@ final class MainViewController: BaseViewController {
         self.guideView.addGuideView()
     }
 
-    override func endEditingView() {
-        self.guideView.didTapAroundToHideGuideView()
-    }
-
     override func setupNavigationBar() {
         super.setupNavigationBar()
 
@@ -188,6 +184,10 @@ final class MainViewController: BaseViewController {
         self.navigationItem.largeTitleDisplayMode = .automatic
         self.navigationItem.leftBarButtonItem = appTitleView
         self.navigationItem.rightBarButtonItem = settingButtonView
+    }
+
+    override func endEditingView() {
+        self.guideView.didTapAroundToHideGuideView()
     }
     
     // MARK: - func

--- a/Manito/Manito/Screens/Main/MainViewController.swift
+++ b/Manito/Manito/Screens/Main/MainViewController.swift
@@ -171,7 +171,7 @@ final class MainViewController: BaseViewController {
         self.guideView.snp.makeConstraints {
             $0.top.trailing.equalToSuperview().inset(30)
         }
-        self.guideView.addGuideView()
+        self.guideView.setupGuideViewLayout()
     }
 
     override func setupNavigationBar() {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
GuideView가 BaseViewController 내부에 들어가 있어서 View 분리를 진행할 때 어려움이 있습니다. GuideView가 BaseViewController 내부에 메소드와 변수들을 만들어둬서 BaseViewController, UIViewController와의 의존성이 높습니다.
따라서 GuideView를 따로 UIView로 떼어내어 의존도를 낮춥니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### ☑️ GuideView를 BaseViewController로부터 분리해냈습니다. 
일단 BaseViewController가 가지고 있는 UI Component들과 메소드들을 분리해냈습니다. 그리고 type(Screen) 별로 다른 Configuration, Layout 등을 가질 수 있도록 했습니다.

```swift
    enum GuideType: String {
        case letter
        case main
        case detailing
    }
```

총 세가지의 타입을 만들었습니다. 타입은 Screen별로 나눴고 letter, main, detailing에서만 Guide를 사용하기 때문에 타입은 세가지만 존재합니다. 각각은 사용하는 메소드가 조금씩 다릅니다.

![스크린샷 2023-03-15 오후 12 38 57](https://user-images.githubusercontent.com/55099365/225200137-6ae161a3-f0ec-4040-8fec-b7c3b50d8074.png)


* 초록색 : 모든 Type에서 사용되는 함수입니다. GuideButton를 눌렀을 때 일어나는 Action과 내부 Configuration이 image, text를 제외하고는 동일하기 때문에 init() 메소드 내부에서 호출되도록 했습니다.

* 다른색 : 각각의 Type에서 부르는 메소드 입니다. 

#### 각각의 메소드 설명

* `setupGuideViewLayout`
   - Main, Detailing은 일반 View(UIViewController의 View)에 GuideView를 얹고서 사용합니다. 따라서 setupGuideViewLayout 방식을 따릅니다.
   - Letter는 NavigationItem으로 Button를 넣고 NavigationController에 포함된 View 위에서 GuideBox가 나와야 합니다. 따라서 setupGuideViewLayout(in: navigationController)에 있는 Layout 방식을 따릅니다.

* `TapAround`
   - Main, Detailing는 View에서 아무곳이나 눌렀을 때 가이드 뷰가 사라져야 합니다. 따라서 ViewController+Extension에 있는 endEditingView 함수 내부에 didTapAroundToHideGuideView 메소드를 넣어서 사용합니다.
   - Letter는 View, NavigationBar에서 아무곳이나 눌렀을 때 가이드 뷰가 사라져야 합니다. 따라서 GuideView 내부에 NaivigationController와 ViewController의 TapGesture를 다루는 부분을 두고서 didTapAroundToHideGuideView를 action으로 사용하도록 합니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

해당 브랜치에서 GuideView가 잘 뜨는지 터치가 잘 되는지 확인해주시면 됩니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://user-images.githubusercontent.com/55099365/225197873-666500dc-b018-4515-8d04-4091770fb297.mp4


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이번 PR에서 백로그에 있는 `가이드 버튼이 메인 화면에서 안나오는 부분`을 해결했습니다.
cc. @coby5502 
<img width="1008" alt="스크린샷 2023-03-15 오후 12 34 37" src="https://user-images.githubusercontent.com/55099365/225199580-fd601517-bb54-4300-9b95-66c31047d91c.png">


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #400

