### PR TITLE
[CHORE] 마니또 공개 화면에서 생기는 문제들을 해결했습니다.

### DIFF
--- a/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailngCodebaseViewController.swift
@@ -199,7 +199,10 @@ final class DetailingCodebaseViewController: BaseViewController {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
             guard let roomId = self?.roomId else { return }
-            self?.navigationController?.pushViewController(OpenManittoViewController(roomId: roomId), animated: true)
+            let viewController = OpenManittoViewController(roomId: roomId)
+            viewController.modalTransitionStyle = .crossDissolve
+            viewController.modalPresentationStyle = .fullScreen
+            self?.present(viewController, animated: true)
         }
         button.addAction(action, for: .touchUpInside)
         button.title = TextLiteral.detailIngViewControllerManitoOpenButton

--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -40,8 +40,8 @@ final class OpenManittoPopupViewController: BaseViewController {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
             guard let parentViewController = self?.presentingViewController else { return }
-            self?.dismiss(animated: false, completion: {
-                parentViewController.dismiss(animated: false)
+            self?.dismiss(animated: true, completion: {
+                parentViewController.dismiss(animated: true)
             })
         }
         button.title = TextLiteral.confirm

--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -39,9 +39,9 @@ final class OpenManittoPopupViewController: BaseViewController {
     private lazy var confirmButton: UIButton = {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
-            guard let parentViewController = self?.presentingViewController as? UINavigationController else { return }
-            self?.dismiss(animated: true, completion: {
-                parentViewController.popToRootViewController(animated: true)
+            guard let parentViewController = self?.presentingViewController else { return }
+            self?.dismiss(animated: false, completion: {
+                parentViewController.dismiss(animated: false)
             })
         }
         button.title = TextLiteral.confirm


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백로그에 적혀있던 마니또 공개 화면에서 생기는 문제들을 해결했습니다.
<img width="912" alt="스크린샷 2023-03-18 오후 6 55 38" src="https://user-images.githubusercontent.com/55099365/226098701-a5bc98ec-e906-493f-9257-a20a6614fb85.png">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

### 🛠️ 마니또 공개 화면에서 내용을 본 후 메인 화면으로 이동하는 플로우 수정
마니또 공개 화면에서 내용을 본 후에 메인 화면이 아닌 디테일-ing 화면으로 이동하도록 수정했습니다.

```swift
guard let parentViewController = self?.presentingViewController else { return }
self?.dismiss(animated: false, completion: {
     parentViewController.dismiss(animated: false)
})
```
이전에는 RootVC로 이동하도록 되어있어서 이를 수정했습니다.
팝업 뷰를 dismiss하고, 마니또 공개 애니메이션(CollectionView 형태)을 dismiss하는 식으로 변경했습니다.

### 🛠️ 마니또 공개 화면에서 나타나는 뒤로가기 버튼 제거
마니또 공개 화면은 present 기능을 통해서 진행됩니다. 따라서 뒤로가기 버튼이 나타날 수 없습니다.
하지만 코드가 navigationController에서 push하는 방식으로 짜여져있어서 생기는 문제점이었습니다.
이를 present하는 방식으로 다시 수정했습니다.

```swift
let viewController = OpenManittoViewController(roomId: roomId)
viewController.modalTransitionStyle = .crossDissolve
viewController.modalPresentationStyle = .fullScreen
self?.present(viewController, animated: true)
```

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

해당 브랜치로 이동 후에 진행해주세요.

**[마니또 공개 당일이 아니더라도 확인하는 방법]**
1. `DetailingViewController`에서 `setupManittoOpenButton` 메소드 안에 isHidden 부분을 false로 설정
    ```swift
    private func setupManittoOpenButton(date: String) {
            guard let endDate = date.stringToDateYYYY() else { return }
            manittoOpenButtonShadowView.isHidden = false
        }
    ```

2. `manittoOpenButton` 변수 안에 있는 action 코드 안에 roomId가 "" 빈값이 들어가도록 해야함 -> 아니면 방 종료될 수도..
      ```swift
      guard let roomId = self?.roomId else { return }
      let viewController = OpenManittoViewController(roomId: "")
      viewController.modalTransitionStyle = .crossDissolve
      viewController.modalPresentationStyle = .fullScreen
      self?.present(viewController, animated: true)
      ```
3. `OpenManittoViewController`에서 `requestWithFriends` 메소드 안에 DispatchQueue.main.async 코드를 viewDidLoad 메소드로 옮기기
    ```swift
    override func viewDidLoad() {
            super.viewDidLoad()
            DispatchQueue.main.async {
                self.requestRoomInfo(roomId: self.roomId)
                self.animateCollectionView()
                self.manittoCollectionView.reloadData()
            }
    }
    ```


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

room이 끝나면 안되는 상황이라서 roomId를 넣지 않았습니다. 
따라서 CollectionView가 안뜨는게 정상입니다. 놀라지 마세요....🫡

https://user-images.githubusercontent.com/55099365/226099148-a06fbd16-457d-4fb3-bc60-a9e0e9627a8a.mp4

<br>

화면이 animated 없이 종료되는데 어떠신가요? @MMMIIIN @dangsal @coby5502 

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
* DetailCodebaseViewController 코드가 600줄을 넘네요...
* Interaction 부분도 얼른 컨벤션 수정 + 리팩토링 하겠습니다..

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #417 
