### PR TITLE
[FIX] 마니또 공개 화면에서 레이아웃이 깨지는 문제를 해결했습니다.

### DIFF
--- a/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoPopupViewController.swift
@@ -79,7 +79,7 @@ final class OpenManittoPopupViewController: BaseViewController {
         
         popupView.addSubview(typingLabel)
         typingLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(popupView.frame.height * 0.36)
+            $0.centerY.equalToSuperview().offset(-30)
             $0.centerX.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(24)
         }

--- a/Manito/Manito/Screens/Interaction/OpenManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoViewController.swift
@@ -20,9 +20,9 @@ final class OpenManittoViewController: BaseViewController {
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 29.0
         static let collectionVerticalSpacing: CGFloat = 37.0
-        static let cellLineSpacing: CGFloat = 39.0
-        static let cellInteritemSpacing: CGFloat = 20.0
-        static let cellWidth: CGFloat = (UIScreen.main.bounds.size.width - (collectionHorizontalSpacing * 2 + cellLineSpacing * 2)) / 3
+        static let cellLineSpacing: CGFloat = 20.0
+        static let cellInteritemSpacing: CGFloat = 39.0
+        static let cellWidth: CGFloat = floor((UIScreen.main.bounds.size.width - (collectionHorizontalSpacing * 2 + cellInteritemSpacing * 2)) / 3)
         static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,

--- a/Manito/Manito/Screens/Interaction/OpenManittoViewController.swift
+++ b/Manito/Manito/Screens/Interaction/OpenManittoViewController.swift
@@ -20,9 +20,9 @@ final class OpenManittoViewController: BaseViewController {
     private enum Size {
         static let collectionHorizontalSpacing: CGFloat = 29.0
         static let collectionVerticalSpacing: CGFloat = 37.0
-        static let cellInterSpacing: CGFloat = 39.0
-        static let cellLineSpacing: CGFloat = 20.0
-        static let cellWidth: CGFloat = (UIScreen.main.bounds.size.width - (collectionHorizontalSpacing * 2 + cellInterSpacing * 2)) / 3
+        static let cellLineSpacing: CGFloat = 39.0
+        static let cellInteritemSpacing: CGFloat = 20.0
+        static let cellWidth: CGFloat = (UIScreen.main.bounds.size.width - (collectionHorizontalSpacing * 2 + cellLineSpacing * 2)) / 3
         static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,
@@ -36,7 +36,7 @@ final class OpenManittoViewController: BaseViewController {
         flowLayout.scrollDirection = .vertical
         flowLayout.sectionInset = Size.collectionInset
         flowLayout.minimumLineSpacing = Size.cellLineSpacing
-        flowLayout.minimumInteritemSpacing = Size.cellInterSpacing
+        flowLayout.minimumInteritemSpacing = Size.cellInteritemSpacing
         flowLayout.sectionHeadersPinToVisibleBounds = true
         flowLayout.itemSize = CGSize(width: Size.cellWidth, height: Size.cellWidth)
         return flowLayout


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
마니또 공개 화면에서 XR 기종에서 레이아웃이 깨지는 문제가 발생하여 이를 해결했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 🛠️ CollectionView Layout를 수정했습니다.
정해진 width 값이 소수점을 가지고 있어서 결과적으로 전체 화면보다 더 큰 값을 가지게 되어 collectionView가 무너졌던 거 같습니다.

XR 기종에서 cell width 값을 확인하면 이렇게 찍힙니다.
![스크린샷 2023-03-18 오후 9 33 15](https://user-images.githubusercontent.com/55099365/226106477-9324b24b-eeb7-455b-8b11-4880fbecf719.png)

해당 interitemspacing, insetspacing, cell width를 더하면 전체 width 사이즈인 414를 넘게 됩니다. 따라서 floor로 감싸서 내림값을 가지도록 수정했습니다.
![스크린샷 2023-03-18 오후 9 32 51](https://user-images.githubusercontent.com/55099365/226106519-8c7ac879-8448-464d-ad09-557d0e3d6cf4.png)

| iPhone SE(3rd) | iPhone 12 mini | iPhone 14 Pro Max |
|--------|--------|--------|
| <img src="https://user-images.githubusercontent.com/55099365/226106577-f1d3fec4-d399-4741-a581-57edaa57fa36.png" width="350"> |<img src="https://user-images.githubusercontent.com/55099365/226106600-b88f575f-a9e9-4a02-8904-27f987211b9b.png" width="350">  |<img src="https://user-images.githubusercontent.com/55099365/226106618-9f438ac8-3e45-4713-a4b7-c99daa71e6cf.png" width="350"> |


iPhone XR

https://user-images.githubusercontent.com/55099365/226106743-61968354-3c2f-42c0-9b66-16ecef21196d.mp4

<br>

### 🛠️ 팝업에서 라벨 레이아웃(top)이 맞지 않아서 수정했습니다.
top이 아니라 뷰의 centerY로부터 offset를 잡도록 수정했습니다.

| iPhone SE(3rd) | iPhone 12 mini |
|--------|--------|
| <img src="https://user-images.githubusercontent.com/55099365/226106816-ef60e55b-d357-4b80-a714-dc5c8aee49ca.png" width="350"> |<img src="https://user-images.githubusercontent.com/55099365/226106817-04023de5-bf34-4de4-8aa7-d22dba0477d0.png" width="350">  |
| iPhone Pro Max | iPhone 14 |
|<img src="https://user-images.githubusercontent.com/55099365/226106815-2a3507d2-84b2-4eb3-8eae-536479c7a798.png" width="350"> |<img src="https://user-images.githubusercontent.com/55099365/226106819-b3e1e1eb-8ae6-440f-a3de-e61f15b26420.png" width="350">


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

* Detail-ing의 마니또 공개 버튼 isHidden를 false로 설정해줍니다. (DetailingViewController > `setupManittoOpenButton`)
* 버튼을 누르면 공개 화면을 확인할 수 있습니다. -> 대신 마니또 내용도 확인 가능^_ㅠ

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
* 다른 뷰 CollectionView Cell들은 괜찮은가..


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #421
