### PR TITLE
[CHORE] 초대코드 입력시 대문자로 입력되도록 수정 

### DIFF
--- a/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
+++ b/Manito/Manito/Screens/ParticipateRoom/UIComponent/InputInvitedCodeView.swift
@@ -30,7 +30,7 @@ final class InputInvitedCodeView: UIView {
         textField.returnKeyType = .done
         textField.delegate = self
         textField.autocorrectionType = .no
-        textField.autocapitalizationType = .none
+        textField.autocapitalizationType = .allCharacters
         textField.becomeFirstResponder()
         return textField
     }()    
@@ -104,5 +104,7 @@ extension InputInvitedCodeView: UITextFieldDelegate {
         guard let textCount = roomCodeTextField.text?.count else { return }
         let hasText = textCount >= maxLength
         changeNextButtonEnableStatus?(hasText)
+        
+        textField.text = textField.text?.uppercased()
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재 초대코드 입력시 소문자가 입력되기 때문에 유저가 불편함을 느낀다는 피드백을 받았습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
입력이 항상 대문자로 변경되도록 수정하였습니다.
- 일단 textField.autocapitalizationType = .allCharacters 를 설정해서 모든 글자가 대문자가 되도록 했습니다.
- textField.text = textField.text?.uppercased() 를 통해 소문자를 굳이 입력하더라도 대문자로 변경해서 입력되도록 하였습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/451-invitecode-uppercase 오셔서 참가하기에서 소문자와 대문자 눌러보시면 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/59243274/37e5f4bf-c358-44aa-8c6d-7b8f4f14b65a



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #451 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
