### PR TITLE
[FEAT] 미션 수정 View를 추가했습니다 (View 분리를 곁들인...)

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		39D95265285B097800183B09 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D95264285B097800183B09 /* CalendarView.swift */; };
 		39E099AD287FC020004F464E /* LetterDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E099AC287FC020004F464E /* LetterDTO.swift */; };
 		39EE956D2A401ED400AF6857 /* DetailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EE956C2A401ED400AF6857 /* DetailingView.swift */; };
+		39EE956F2A404A3800AF6857 /* MissionEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EE956E2A404A3800AF6857 /* MissionEditViewController.swift */; };
 		39EEF65628CB3BB200437654 /* LoginProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65528CB3BB200437654 /* LoginProtocol.swift */; };
 		39EEF65828CB3C1100437654 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65728CB3C1100437654 /* Login.swift */; };
 		39EEF65A28CB3C7B00437654 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65928CB3C7B00437654 /* Token.swift */; };
@@ -235,6 +236,7 @@
 		39E099AC287FC020004F464E /* LetterDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterDTO.swift; sourceTree = "<group>"; };
 		39E6321328BDE59C00CFC6C4 /* Manito.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Manito.entitlements; sourceTree = "<group>"; };
 		39EE956C2A401ED400AF6857 /* DetailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailingView.swift; sourceTree = "<group>"; };
+		39EE956E2A404A3800AF6857 /* MissionEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionEditViewController.swift; sourceTree = "<group>"; };
 		39EEF65528CB3BB200437654 /* LoginProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProtocol.swift; sourceTree = "<group>"; };
 		39EEF65728CB3C1100437654 /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		39EEF65928CB3C7B00437654 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 			isa = PBXGroup;
 			children = (
 				39EE956C2A401ED400AF6857 /* DetailingView.swift */,
+				39EE956E2A404A3800AF6857 /* MissionEditViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1240,6 +1243,7 @@
 				7E7542B32923744300D725CB /* ToastPopupView.swift in Sources */,
 				39CD581B28C4BE8800496E91 /* DetailStartingAPI.swift in Sources */,
 				39C957D22879523200A04A2B /* Date+Extension.swift in Sources */,
+				39EE956F2A404A3800AF6857 /* MissionEditViewController.swift in Sources */,
 				B5F5250A2851A06700614FF7 /* DetailWaitViewController.swift in Sources */,
 				39C957D02879521400A04A2B /* String+Extension.swift in Sources */,
 				399D17AB2856C83B00F50D9D /* DetailEditViewController.swift in Sources */,

--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		39CD582128C4C3E800496E91 /* DetailDoneAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CD582028C4C3E800496E91 /* DetailDoneAPI.swift */; };
 		39D95265285B097800183B09 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D95264285B097800183B09 /* CalendarView.swift */; };
 		39E099AD287FC020004F464E /* LetterDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E099AC287FC020004F464E /* LetterDTO.swift */; };
+		39EE956D2A401ED400AF6857 /* DetailingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EE956C2A401ED400AF6857 /* DetailingView.swift */; };
 		39EEF65628CB3BB200437654 /* LoginProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65528CB3BB200437654 /* LoginProtocol.swift */; };
 		39EEF65828CB3C1100437654 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65728CB3C1100437654 /* Login.swift */; };
 		39EEF65A28CB3C7B00437654 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EEF65928CB3C7B00437654 /* Token.swift */; };
@@ -233,6 +234,7 @@
 		39D95264285B097800183B09 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
 		39E099AC287FC020004F464E /* LetterDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterDTO.swift; sourceTree = "<group>"; };
 		39E6321328BDE59C00CFC6C4 /* Manito.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Manito.entitlements; sourceTree = "<group>"; };
+		39EE956C2A401ED400AF6857 /* DetailingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailingView.swift; sourceTree = "<group>"; };
 		39EEF65528CB3BB200437654 /* LoginProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProtocol.swift; sourceTree = "<group>"; };
 		39EEF65728CB3C1100437654 /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		39EEF65928CB3C7B00437654 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -506,6 +508,14 @@
 			path = Request;
 			sourceTree = "<group>";
 		};
+		39EE956B2A401E9600AF6857 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				39EE956C2A401ED400AF6857 /* DetailingView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		7E0C5C342855B1EF00F698D1 /* CreateNickName */ = {
 			isa = PBXGroup;
 			children = (
@@ -728,6 +738,7 @@
 		B5F524E928519B3F00614FF7 /* Detail-Ing */ = {
 			isa = PBXGroup;
 			children = (
+				39EE956B2A401E9600AF6857 /* View */,
 				D75E8C7D28D76FB1004A6C41 /* UIcomponent */,
 				333BF66428571C850039F77F /* Cell */,
 				435B17672913E71400212663 /* DetailingViewController.swift */,
@@ -1250,6 +1261,7 @@
 				B5AE11F229D28CB500F86FF8 /* OpenManittoPopupView.swift in Sources */,
 				B517C04A28D1F7EC0008BED0 /* TokenEndPoint.swift in Sources */,
 				39C957DF2879A35300A04A2B /* RoomDTO.swift in Sources */,
+				39EE956D2A401ED400AF6857 /* DetailingView.swift in Sources */,
 				39C95808287DB05C00A04A2B /* SettingEndPoint.swift in Sources */,
 				39C957F4287D9EB400A04A2B /* APIService.swift in Sources */,
 				B5F524CF28519AA000614FF7 /* AppDelegate.swift in Sources */,

--- a/Manito/Manito/Global/Literal/ImageLiteral.swift
+++ b/Manito/Manito/Global/Literal/ImageLiteral.swift
@@ -22,6 +22,7 @@ enum ImageLiterals {
     static var icMissionInfo: UIImage { .load(name: "ic_missionInfo")}
     static var icRight: UIImage { .load(name: "ic_right")}
     static var icSave: UIImage { .load(name: "ic_save")}
+    static var icPencil: UIImage { .load(name: "ic_pencil") }
     
     // MARK: - button
     

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -164,6 +164,9 @@ enum TextLiteral {
     static let detailIngViewControllerMissionEditTitle: String = "개별 미션 설정"
     static let detailIngViewControllerSelfEditMissionTitle: String = "개별 미션 직접 설정"
     static let detailIngViewControllerResetMissionTitle: String = "기본 미션으로 변경"
+    static let detailIngViewControllerResetMissionAlertTitle: String = "개별 미션을 되돌리시겠습니까?"
+    static let detailIngViewControllerResetMissionAlertMessage: String = "기존에 주어지는 기본 미션으로 재설정됩니다."
+    static let detailIngViewControllerResetMissionAlertOkTitle: String = "되돌리기"
     
     // MARK: - CalendarView
     static let calendarViewAlertMaxTitle: String = "최대 선택 기간을 넘었어요"

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -220,4 +220,8 @@ enum TextLiteral {
     
     // MARK: - InvitedCodeViewController
     static let invitedCodeViewCOntroller: String = "글자를 탭하여 코드를 복사하세요"
+    
+    // MARK: - MissionEditViewController
+    static let missionEditViewControllerChangeMissionAlertTitle: String = ""
+    static let missionEditViewControllerChangeMissionAlertMessage: String = ""
 }

--- a/Manito/Manito/Global/Literal/TextLiteral.swift
+++ b/Manito/Manito/Global/Literal/TextLiteral.swift
@@ -161,6 +161,9 @@ enum TextLiteral {
     static let detailIngViewControllerDoneExitAlertMessage: String = "나간 방은 다시 들어올 수 없어요"
     static let detailIngViewControllerDoneExitAlertAdmin: String = "방장이 방을 삭제하면\n 참여자들의 방도 삭제됩니다"
     static let detailIngViewControllerDetailInformatioin: String = "진행 정보"
+    static let detailIngViewControllerMissionEditTitle: String = "개별 미션 설정"
+    static let detailIngViewControllerSelfEditMissionTitle: String = "개별 미션 직접 설정"
+    static let detailIngViewControllerResetMissionTitle: String = "기본 미션으로 변경"
     
     // MARK: - CalendarView
     static let calendarViewAlertMaxTitle: String = "최대 선택 기간을 넘었어요"

--- a/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/Contents.json
+++ b/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "007aff 2.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/Contents.json
+++ b/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "007aff 2.pdf",
+      "filename" : "ic_pencil.pdf",
       "idiom" : "universal"
     }
   ],

--- a/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/ic_pencil.pdf
+++ b/Manito/Manito/Global/Resource/Assets.xcassets/ic_pencil.imageset/ic_pencil.pdf
@@ -1,0 +1,167 @@
+%PDF-1.7
+
+1 0 obj
+  << /Type /XObject
+     /Subtype /Image
+     /BitsPerComponent 8
+     /Length 2 0 R
+     /Height 288
+     /Width 288
+     /ColorSpace /DeviceGray
+     /Filter [ /FlateDecode ]
+  >>
+stream
+xÝÏA®ë8ÀÿKÏ ]…'Ù’S+¡ÉÐÿÞóß&Ný$m§~’¿¶…S?É_ÛÂ©Ÿä¯máÔOò×¶pê'ùk[8õ“üµ-œúIþÚN}—þ)p9%RàrJ¤Àå”<HË)y—Sò .§äA
+\NÉƒ¸œ’)p•æÙßÂ©yöR`žý-œšgÿ æÙßÂ©yöR`žý-œšgÿ æÙßÂ©yöR`žý-œšgÿ æÙßÂ©yöR`žý-œšgÿ æÙßÂ©yößç»Óƒ¨˜¾Æç*¦)P1}ÏULR búŸ«˜¤@Åô5>W1=HŠék|®bzÓ×ø\Åô *¦¯ñ¹ŠéA
+TL_ãsÓƒ¨˜>ÍW*¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©bº—›Aø9jáNáç¨„[8„Ÿ£vnáT~ŽÚA¸…SAø9jáNáç¨„[8„Ÿ£vnáT~ŽÚA¸…SAø9já
+‚ðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0ÿÀƒðNºULƒ0çÙ¯˜^E¥yöïŠiËZÅô**Í³?xWL[Ö*¦WQižýÁ»bÚ²V1½ŠJóìÞÓ–µŠéUTšgð®˜¶¬UL¯¢Ò<ûƒwÅ´e­bz•æÙ¼+¦-kÓ«¨4Ïþà]1mY«˜^E¥yöïŠiËZ^E¥Á{ðnYÂ lYÂ«¨4xÞ-kA„-kAx•ïÁ»e-ƒ°e-¯¢Òà=x·¬a¶¬áUT¼ï–µ Â–µ ¼ŠJƒ÷àÝ²„AØ²„WQið¼[Ö‚0[Ö‚ð**ÞƒwËZaËZ^E¥Á{ðnYÂ ¬˜áUT
+Â ¬˜VLƒ0ƒð**aVL+¦A„Ax•‚0+¦Ó Â ¼ŠJA„ÓŠia^E¥ ÂŠiÅ4ƒ0¯¢RaÅ´b„A„WQ)ƒ°bZ1Â Â«¨„AX1­˜aáUT
+Â ¬˜VLƒ0ƒðš´¬áàÝ²„A„7Ð¤e-ï–µ Â ¼&-kA8x·¬aá4iYÂÁ»e-ƒ0o IËZÞ-kA„AxMZÖ‚pðnYÂ ÂhÒ²„ƒwËZaÞ@“–µ ¼[Ö‚0ƒðš´¬áàÝ²„A„)°Â…yöƒ0ƒð V¸0Ï~a¤À
+æÙÂ ÂƒXáÂ<ûA„Ax+\˜g?ƒ0R`…óìaáA
+¬pažý Â <H.Ì³„A„)°Â…yöƒpðÂƒXáÂ
+ZÖR`…+\hY;H.¬p¡eí V¸°Â…–µƒXáÂ
+ZÖR`…+\hY;H.¬p¡eí V¸°Â…–µƒXáÂ
+ZÖÞç»+\ØÂ©–µ÷ùî
+¶pªeí}¾»Â…-œjY{Ÿï®pa§ZÖÞç»+\ØÂ©–µ÷ùî
+¶pªeí}¾»Â…-œjY{Ÿï®pa§ZÖÞç»+\ØÂ©–µ×øÜ
+ör³eí5>·Â…½ÜlY{Ï­pa/7[Ö^ãs+\ØËÍ–µ×øÜ
+ör³eí5>·Â…½ÜlY{Ï­pa/7[Ö^ãs+\ØËÍ–µ×øÜ
+ör³eíi¾²Â…‡8Þ²ö4_YáÂCoY{š¯¬pá!Ž·¬=ÍWV¸ðÇ[Öžæ++\xˆã-kOó•.<Äñ–µ§ùÊ
+âxËÚÓ|e…q¼eíi¾²Â…‡8Þ²öÇW¸ð4_iY{ˆã+\xš¯´¬=Äñ.<ÍWZÖâø
+žæ+-kq|…Oó•–µ‡8¾Â…§ùJËÚC_áÂÓ|¥eí!Ž¯pái¾Ò²öÇW¸ð4_iYÛËÍ.¼ÆçZÖörs…¯ñ¹–µ½Ü\áÂk|®em/7W¸ðŸkYÛËÍ.¼ÆçZÖörs…¯ñ¹–µ½Ü\áÂk|®em/7W¸ðŸkYÛËÍ.¼ÆçZÖ¶pj…ïóÝ–µ-œZáÂû|·em§V¸ð>ßmYÛÂ©.¼Ïw[Ö¶pj…ïóÝ–µ-œZáÂû|·em§V¸ð>ßmYÛÂ©.¼Ïw[Ö¶pj…ïóÝ–µ.¬pá ZÖV¸°Â…ƒhY[áÂ
+R em…+\8H–µ.¬pá ZÖV¸°Â…ƒhY[áÂ
+R em…+\8H–µ.¬pá ‚pðÂyöW¸pA„A8Ïþ
+R ƒ0çÙ_áÂA
+aá<û+\8H Â œg…)„A„óì¯pá ‚0ƒpžý.¤@aÎ³¿Â…ƒÂ ÂyöW¸pA„AØ²6xÞóìß@“ Â lY¼ïyöo Ia¶¬Þƒ÷<û7Ð$ƒ0[ÖïÁ{žýh„A„-kƒ÷à=Ïþ4	Â Â–µÁ{ðžgÿšaaËÚà=xÏ³M‚0ƒ°emð¼çÙ¿&A„AØ²6xÞóìß@“ Â lY¼ƒ°bz•‚0ƒ°emðÂŠéUT
+Â Â–µÁ;+¦WQ)ƒ0[Öï ¬˜^E¥ Â lY¼ƒ°bz•‚0ƒ°emðÂŠéUT
+Â Â–µÁ;+¦WQ)ƒ0[Öï ¬˜^E¥ Â lY¼ƒ°bz•‚°b„Ó ÂÁû**aËZVLƒ0ï«¨„-kAX1Â ¼¯¢R¶¬aÅ4ƒpð¾ŠJAØ²„Ó ÂÁû**aËZVLƒ0ï«¨„-kAX1Â ¼¯¢R¶¬aÅ4ƒpð¾ŠJAØ²„Ó ÂÁû**aËZÅtð¼ïŠéUTª˜¶¬ULïÁ{ð®˜^E¥ŠiËZÅtð¼ïŠéUTª˜¶¬ULïÁ{ð®˜^E¥ŠiËZÅtð¼ïŠéUTª˜¶¬ULïÁ{ð®˜^E¥ŠiËZÅtð¼ïŠéUTª˜¶¬ULïÁ{ð®˜^E¥ŠiËZÅtð¼ïŠéUTª˜Î³„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶Aø~„ƒw~…¶A¸Â… üµƒp§‚ðsÔÂ-œ
+ÂÏQ;·p*?Gí ÜÂ© üµƒp§‚ðsÔÂ-œ
+ÂÏQ;·p*?Gí ÜÂ© üµƒp/7+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©búÇ+¦WQ©bú4_©˜¤@Åô5>W1=HŠék|®bzÓ×ø\Åô *¦¯ñ¹ŠéA
+TL_ãsÓƒ¨˜¾Æç*¦)P1}ÏULR búŸ«˜¤@Åô}¾;ÏþNÍ³óìoáÔ<û)0ÏþNÍ³óìoáÔ<û)0ÏþNÍ³óìoáÔ<û)0ÏþNÍ³óìoáÔ<û)0ÏþNÍ³•RàrJ¤Àå”<HË)y—Sò .§äA
+\NÉƒ¸œ’)p9%Rà»ôßÂ©Ÿä¯máÔOò×¶pê'ùk[8õ“üµ-œúIþÚNý$m§~’¿¶…S?É_ÛÂ©×üþ²
+endstream
+endobj
+
+2 0 obj
+  3032
+endobj
+
+3 0 obj
+  << /Type /XObject
+     /Subtype /Image
+     /BitsPerComponent 8
+     /Length 4 0 R
+     /Height 288
+     /SMask 1 0 R
+     /Width 288
+     /ColorSpace /DeviceRGB
+     /Filter [ /FlateDecode ]
+  >>
+stream
+xíÜ1’Ä6DQÊ'sè+ûö¯¬ÙÈ~õ3G$¨M÷?ìµ¿ÿ=3³øÌ¬>Å#3ë€OñÈÌ:àS<2³øÌ¬>Å#3ë€OñÈÌ:àS<23_ŽÛ’Ý€‹v[²pÑnKv.ÚmÉnÀE»-Ù¸h·%»í¶d7à¢Ý–ì\´Û’ÍÂ•uèT­C¶ÃïÐ©8Z‡l†ß¡Sq´Ù.¿C§âh²]~‡NÅÑ:d»0üŠ£uÈvaø:GëíÂð;t*ŽÖ!Û…áwèT­CöUL87Û…áçfï1ÆÜl†Ÿ›½Çs³]~nöcÌÍvaø¹Ù{Œ17Û…áçfï1ÆÜl†Ÿ›½Çs³]~nöcÌÍvaø¹Ù{Œ17Û…áçfbV¹Ù,\YnöÄ@r³Y¸²Üì‰äf³pe¹ÙÉÍfáÊr³'’›ÍÂ•åfO$7›…+ËÍžHn6W–›=1Ül®,7{b ¹Ù,\YnâÔBf>¡Sq4!³Ÿ‡Ð©8šY„ÏCèTMÈ,Âç!t*Ž&dáó:G2‹ðyŠ£	™Eø<„NÅÑ„Ì"|B§âhBf>¡ÑØ¿ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡þØ¤ƒÛÌMÃB¡&ØIn6WÖ¡žæV‰×åf³peZàin•x]n6WÖ¡žæV‰×åf³peZàin•x]n6WÖ¡žæV‰×åf³peZàin•x]n6WÖ¡žæV‰×åf³peZàin•x]n6WÖ¡žæV‰×	Ù(þõOOC\tY
+UâuB6
+GQ<qÑeiX(T‰×	Ù(üEñ4ÄE—¥a¡P%^'d£ðwÅÓ]–†…B•xÂßQOC\tY
+UâuB6
+GQ<qÑeiX(T‰×	Ù(üEñ4ÄE—¥a¡P%^'d£ðwÅÓ]–†…B•xÂßQOC\tY
+¥ã7…l®LHÃÂÜÒñ›B
+Ù,\™†…¹¥ã7…4,²Y¸2!sKÇo
+iX(d³peBæ–ŽßÒ°PÈfáÊ„4,Ì-¿)¤a¡ÍÂ•	iX˜[:~SHÃB!›…+Ò°0·tü¦†…B6W&¤aanéøM!…l®LHÃÂÜÒñ›B
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+YCÜKYFUâuB
+Ù.¿wþüoÿí·ð³Ï_§a¡íÂð{ÇßQÛoágŸ¿NÃB!Û…á÷Ž¿£(¶ßÂÏ>†…B¶ÃïGQl¿…Ÿ}þ:…l†ß;þŽ¢Ø~?ûüu
+Ù.¿wüE±ý~öùë4,²]~ïø;Šbû-üìó×iX(d»0üÞñwÅö[øÙç¯Ó°PÈvaø½ãï(Ší·ð³Ï_·ÀS!Û…áÏm4ö_–íÂðç6û/Ëvaøsý—e»0ü¹ÆþË²]þÜFcÿeÙ.n£±ÿ²l†?·ÑØY¶ÃŸÛhì¿,Û…áÏm4ö_–}žÛ©8ZYöULxn§âheÙW1á¹Š£•e_Å„çv*ŽV–}žÛ©8ZYöULxn§âheÙW1á¹Š£•e_Å„çv*ŽV–}žÛ©8ZYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYöcœÛ…8uYö!f57{b eÙ‡˜ÕÜì‰”ebVs³'R–}ˆYÍÍžHYö!f57{b eÙ‡˜ÕÜì‰”ebVs³'R–}ˆYÍÍžHYö!f57{b eÙ™›}ˆY•eOdnö!fU–=1¹Ù‡˜UYöÄ@æfbVeÙ™›}ˆY•eOdnö!fU–=1¹Ù‡˜UYöÄ@æfbVeÙ™›}ˆY•u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u!N=7{1–u*Ž67û*&\Ö©8ÚÜì«˜pY§âhs³¯bÂeŠ£ÍÍ¾Š	—u*Ž67û*&\Ö©8ÚÜì«˜pY§âhs³¯bÂeŠ£ÍÍ¾Š	—u*Ž67û*&\Öhìn¶Ã/k4ö?7Û…á—5ûŸ›íÂðËýÏÍvaøeÆþçf»0ü²Fcÿs³]~Y£±ÿ¹Ù.¿¬ÑØÿÜl†_Öhìn¶ÃZà©Pìdn¶ÃÒ°P¨	v27Û…áiX(Ô;™›íÂð…4,j‚ÌÍvaøB
+5ÁNæf»0|!…š`'s³]¾†…BM°“¹Ù._HÃB¡&ØÉÜl†/¤a¡Pìdn¶ÃÒ°P¨¯‹Zài‡¬!îEHÃB¡J¼.j§²†¸!…*ñº¨žvÈâ^„4,ªÄë¢xÚ!kˆ{Ò°P¨¯‹Zài‡¬!îEHÃB¡J¼.j§²†¸!…*ñº¨žvÈâ^„4,ªÄë¢xÚ!kˆ{Ò°P¨¯‹Zài‡¬!îEHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®LHÃB¡J¼.JÃÂÜl®L(¿)”ŽßÒ°0ÊfáÊ„*ñ:¡tü¦†…Q6W&T‰×	¥ã7…4,Œ²Y¸2¡J¼N(¿)¤aa”ÍÂ•	UâuBéøM!£l®L¨¯JÇo
+iXe³peB•xP:~SHÃÂ(›…+ªÄë„Òñ›BFÙ,\™P%^'”ŽßÒ°0ÊfáÊ„*ñºÜxµÀÓÜl®,·J¼.·žF-ð47›…+Ë­¯Ëm§Q<ÍÍfáÊr«Äër[àiÔOs³Y¸²Ü*ñºÜxµÀÓÜl®,·J¼.·žF-ð47›…+Ë­¯Ëm§Q<ÍÍfáÊr«Äër[àiÔOs³Y¸²Ü*ñºÜxµÀÓÜl®,·&Ø‰ÐO…ìr|Bý±I¡ž
+Ùåø„úc“B<²ËñõÇ&…x*d—ãêM
+-ðTÈ.Ç7 Ô›Zà©]Žo@¨?6)´ÀS!»ß€PlRh§Bv9¾¡þØ¤ÐO…ìr|B£±!³Ÿ‡Ð©8šY„ÏCèTMÈ,Âç!t*Ž&dáó:G2‹ðyŠ£	™Eø<„NÅÑ„Ì"|B§âhBf>¡Sq4!³Ÿ‡Ð…8un6W–›=1Ül®,7{b ¹Ù,\YnöÄ@r³Y¸²Üì‰äf³pe¹ÙÉÍfáÊr³'’›ÍÂ•åfO$7›…+ËÍžHn6W–›}ˆYåf»0üÜì=Æ˜›íÂðs³÷cn¶ÃÏÍÞcŒ¹Ù.?7{1æf»0üÜì=Æ˜›íÂðs³÷cn¶ÃÏÍÞcŒ¹Ù.?7{1æf»0üÜì«˜p‡NÅÑ:d»0üŠ£uÈvaø:GëíÂð;t*ŽÖ!Û…áwèT­C¶ÃïÐ©8Z‡l†ß¡Sq´Ù.¿C§âh²]~‡NÅÑ:d³penKv.ÚmÉnÀE»-Ù¸h·%»í¶d7à¢Ý–ì\´Û’Ý€‹v[²pÑnKf¾œ#3ë€OñÈÌ:àS<2³øÌ¬>Å#3ë€OñÈÌ:àS<2³øÌ¬>Å#³×þYx&m
+endstream
+endobj
+
+4 0 obj
+  3151
+endobj
+
+5 0 obj
+  << /XObject << /X1 3 0 R >> >>
+endobj
+
+6 0 obj
+  << /Length 7 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.000000 18.000000 m
+18.000000 18.000000 l
+18.000000 0.000000 l
+0.000000 0.000000 l
+0.000000 18.000000 l
+h
+W
+n
+q
+18.000000 0.000000 0.000000 18.000000 0.000000 0.000000 cm
+/X1 Do
+Q
+n
+Q
+
+endstream
+endobj
+
+7 0 obj
+  273
+endobj
+
+8 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 18.000000 18.000000 ]
+     /Resources 5 0 R
+     /Contents 6 0 R
+     /Parent 9 0 R
+  >>
+endobj
+
+9 0 obj
+  << /Kids [ 8 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+10 0 obj
+  << /Pages 9 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000010 00000 n
+0000003258 00000 n
+0000003281 00000 n
+0000006665 00000 n
+0000006688 00000 n
+0000006737 00000 n
+0000007066 00000 n
+0000007088 00000 n
+0000007261 00000 n
+0000007335 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 10 0 R
+   /Size 11
+>>
+startxref
+7395
+%%EOF

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -94,8 +94,8 @@ final class DetailingViewController: BaseViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    private func presentEditMissionView() {
-        let viewController = MissionEditViewController()
+    private func presentEditMissionView(mission: String) {
+        let viewController = MissionEditViewController(mission: mission)
         viewController.modalPresentationStyle = .overCurrentContext
         self.present(viewController, animated: true)
     }
@@ -183,10 +183,10 @@ final class DetailingViewController: BaseViewController {
 }
 
 extension DetailingViewController: DetailingDelegate {
-    func editMissionButtonDidTap() {
+    func editMissionButtonDidTap(mission: String) {
         typealias AlertAction = ((UIAlertAction) -> ())
         let editMissionAction: AlertAction = { [weak self] _ in
-            self?.presentEditMissionView()
+            self?.presentEditMissionView(mission: mission)
         }
         let resetAction: AlertAction = { [weak self] _ in
             self?.resetMission()

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -102,8 +102,14 @@ final class DetailingViewController: BaseViewController {
     }
     
     private func resetMission() {
-        // FIXME: - api 연결 해야함.
-        print("미션 되돌리기 API 연결")
+        self.makeRequestAlert(title: TextLiteral.detailIngViewControllerResetMissionAlertTitle,
+                              message: TextLiteral.detailIngViewControllerResetMissionAlertMessage,
+                              okTitle: TextLiteral.detailIngViewControllerResetMissionAlertOkTitle,
+                              okStyle: .default,
+                              okAction: { [weak self] _ in
+            // FIXME: - API 연결
+            self?.dismiss(animated: true)
+        })
     }
     
     // MARK: - network

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -94,6 +94,16 @@ final class DetailingViewController: BaseViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
+    private func presentEditMissionView() {
+        // FIXME: - view 연결
+        print("view 연결")
+    }
+    
+    private func resetMission() {
+        // FIXME: - api 연결 해야함.
+        print("미션 되돌리기 API 연결")
+    }
+    
     // MARK: - network
    
     private func requestRoomInfo(completionHandler: @escaping ((Result<Room, NetworkError>) -> Void)) {
@@ -173,12 +183,21 @@ final class DetailingViewController: BaseViewController {
 
 extension DetailingViewController: DetailingDelegate {
     func editMissionButtonDidTap() {
+        typealias AlertAction = ((UIAlertAction) -> ())
+        let editMissionAction: AlertAction = { [weak self] _ in
+            self?.presentEditMissionView()
+        }
+        let resetAction: AlertAction = { [weak self] _ in
+            self?.resetMission()
+        }
+        
         self.makeActionSheet(title: TextLiteral.detailIngViewControllerMissionEditTitle,
                              actionTitles: [
                                 TextLiteral.detailIngViewControllerSelfEditMissionTitle,
                                 TextLiteral.detailIngViewControllerResetMissionTitle,
                                 TextLiteral.cancel],
-                             actionStyle: [.default, .default, .cancel], actions: [nil, nil, nil])
+                             actionStyle: [.default, .default, .cancel],
+                             actions: [editMissionAction, resetAction, nil])
     }
     
     func listBackDidTap() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -96,6 +96,7 @@ final class DetailingViewController: BaseViewController {
     
     private func presentEditMissionView(mission: String) {
         let viewController = MissionEditViewController(mission: mission)
+        viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .overCurrentContext
         self.present(viewController, animated: true)
     }

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -95,8 +95,9 @@ final class DetailingViewController: BaseViewController {
     }
     
     private func presentEditMissionView() {
-        // FIXME: - view 연결
-        print("view 연결")
+        let viewController = MissionEditViewController()
+        viewController.modalPresentationStyle = .overCurrentContext
+        self.present(viewController, animated: true)
     }
     
     private func resetMission() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -13,217 +13,12 @@ final class DetailingViewController: BaseViewController {
     
     private let detailIngService: DetailIngAPI = DetailIngAPI(apiService: APIService())
     private let detailDoneService: DetailDoneAPI = DetailDoneAPI(apiService: APIService())
-    
-    private enum RoomType: String {
-        case PROCESSING
-        case POST
-    }
-    
     private let roomId: String
-    private var roomType: RoomType = .PROCESSING
-    private var isTappedManittee: Bool = false
     private var missionId: String = ""
-    private var manittoNickname: String = ""
-    var letterViewController: UIViewController {
-        guard let mission = missionContentsLabel.text else { return UIViewController() }
-        let viewController = LetterViewController(roomState: roomType.rawValue,
-                                                  roomId: roomId,
-                                                  mission: mission,
-                                                  missionId: self.missionId,
-                                                  entryPoint: .notification)
-        return viewController
-    }
 
     // MARK: - property
     
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 34)
-        return label
-    }()
-    private let periodLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .grey002
-        label.font = .font(.regular, ofSize: 16)
-        return label
-    }()
-    private let statusLabel: UILabel = {
-        let label = UILabel()
-        label.layer.masksToBounds = true
-        label.layer.cornerRadius = 11
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 13)
-        label.textAlignment = .center
-        return label
-    }()
-    private let missionBackgroundView: UIView = {
-        var view = UIView()
-        view.backgroundColor = .darkGrey004
-        return view
-    }()
-    private let missionTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = TextLiteral.individualMissionViewTitleLabel
-        label.textColor = .grey002
-        label.font = .font(.regular, ofSize: 14)
-        return label
-    }()
-    private let missionContentsLabel: UILabel = {
-        let label = UILabel()
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakStrategy = .hangulWordPriority
-        let attributedText = NSAttributedString(string: "", attributes: [.paragraphStyle: paragraphStyle])
-        label.attributedText = attributedText
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 18)
-        return label
-    }()
-    private let informationTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = TextLiteral.detailIngViewControllerDetailInformatioin
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 16)
-        return label
-    }()
-    private lazy var manitteeBackView: UIView = {
-        let view = UIView()
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTappedManittee))
-        view.addGestureRecognizer(tapGesture)
-        view.backgroundColor = .darkGrey002
-        view.makeBorderLayer(color: .white)
-        return view
-    }()
-    private let manitteeImageView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .subOrange
-        view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.grey005.cgColor
-        view.layer.cornerRadius = 49.5
-        return view
-    }()
-    private let manitteeIconView = UIImageView(image: ImageLiterals.icManiTti)
-    private let manitteeLabel: UILabel = {
-        let label = UILabel()
-        label.text = "\(UserDefaultStorage.nickname)의 마니띠"
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 15)
-        return label
-    }()
-    private lazy var listBackView: UIView = {
-        let view = UIView()
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(pushFriendListViewController(_:)))
-        view.addGestureRecognizer(tapGesture)
-        view.backgroundColor = .darkGrey002
-        view.makeBorderLayer(color: .white)
-        return view
-    }()
-    private let listImageView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .subPink
-        view.layer.borderWidth = 1
-        view.layer.borderColor = UIColor.grey005.cgColor
-        view.layer.cornerRadius = 49.5
-        return view
-    }()
-    private let listIconView = UIImageView(image: ImageLiterals.icList)
-    private let listLabel: UILabel = {
-        let label = UILabel()
-        label.text = TextLiteral.togetherFriend
-        label.textColor = .white
-        label.font = .font(.regular, ofSize: 15)
-        return label
-    }()
-    private lazy var letterBoxButton: UIButton = {
-        let button = UIButton(type: .system)
-        let action = UIAction { [weak self] _ in
-            guard let roomType = self?.roomType,
-                  let roomId = self?.roomId,
-                  let mission = self?.missionContentsLabel.text
-            else { return }
-            let letterViewController = LetterViewController(roomState: roomType.rawValue,
-                                                            roomId: roomId,
-                                                            mission: mission,
-                                                            missionId: self?.missionId ?? "",
-                                                            entryPoint: .detail)
-            self?.navigationController?.pushViewController(letterViewController, animated: true)
-        }
-        button.addAction(action, for: .touchUpInside)
-        button.setTitle(TextLiteral.letterViewControllerTitle, for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = .font(.regular, ofSize: 15)
-        button.backgroundColor = .darkGrey002
-        button.makeBorderLayer(color: .white)
-        return button
-    }()
-    private lazy var manittoMemoryButton: UIButton = {
-        let button = UIButton(type: .system)
-        let action = UIAction { [weak self] _ in
-            guard let roomId = self?.roomId else { return }
-            let viewController = MemoryViewController(roomId: roomId)
-            self?.navigationController?.pushViewController(viewController, animated: true)
-        }
-        button.addAction(action, for: .touchUpInside)
-        button.setTitle(TextLiteral.memoryViewControllerTitleLabel, for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = .font(.regular, ofSize: 15)
-        button.backgroundColor = .darkGrey002
-        button.makeBorderLayer(color: .white)
-        return button
-    }()
-    private let manitteeAnimationLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .white
-        label.alpha = 0
-        label.font = .font(.regular, ofSize: 15)
-        return label
-    }()
-    private let manitiRealIconView: UIImageView = {
-        let imageView = UIImageView(image: ImageLiterals.imgMa)
-        imageView.alpha = 0
-        return imageView
-    }()
-    private let manittoOpenButtonShadowView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .mainRed
-        view.layer.masksToBounds = false
-        view.layer.cornerRadius = 30
-        view.makeShadow(color: .shadowRed, opacity: 1.0, offset: CGSize(width: 0, height: 6), radius: 1)
-        view.isHidden = true
-        return view
-    }()
-    // FIXME: - 마니또 공개 API 확실히 하기
-    private lazy var manittoOpenButton: MainButton = {
-        let button = MainButton()
-        let action = UIAction { [weak self] _ in
-            guard
-                let roomId = self?.roomId,
-                let manittoNickname = self?.manittoNickname
-            else { return }
-            let viewController = OpenManittoViewController(roomId: roomId, manittoNickname: manittoNickname)
-            viewController.modalTransitionStyle = .crossDissolve
-            viewController.modalPresentationStyle = .fullScreen
-            self?.present(viewController, animated: true)
-        }
-        button.addAction(action, for: .touchUpInside)
-        button.title = TextLiteral.detailIngViewControllerManitoOpenButton
-        return button
-    }()
-    private let badgeLabel: LetterCountBadgeView = {
-        let label = LetterCountBadgeView()
-        label.layer.cornerRadius = 15
-        label.isHidden = true
-        return label
-    }()
-    private let exitButton: UIButton = {
-        let button = UIButton()
-        button.setImage(ImageLiterals.icMore, for: .normal)
-        button.showsMenuAsPrimaryAction = true
-        return button
-    }()
-    private let guideView: GuideView = GuideView(type: .detailing)
+    private let detailingView: DetailingView = DetailingView()
     
     // MARK: - init
     
@@ -242,248 +37,52 @@ final class DetailingViewController: BaseViewController {
     
     // MARK: - life cycle
     
+    override func loadView() {
+        self.view = self.detailingView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureDelegation()
+        self.configureNavigationController()
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupLargeTitleToOriginal()
-        requestRoomInfo()
-    }
-    
-    override func setupLayout() {
-        view.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(19)
-            $0.leading.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
+        self.requestRoomInfo() { [weak self] result in
+            switch result {
+            case .success(let roomInformation):
+                self?.detailingView.updateDetailingView(room: roomInformation)
+            case .failure:
+                print("error")
+            }
         }
-        
-        view.addSubview(periodLabel)
-        periodLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
-            $0.leading.equalTo(view.safeAreaLayoutGuide).inset(24)
-        }
-        
-        view.addSubview(statusLabel)
-        statusLabel.snp.makeConstraints {
-            $0.centerY.equalTo(titleLabel.snp.centerY)
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(6)
-            $0.width.equalTo(67)
-            $0.height.equalTo(23)
-        }
-
-        view.addSubview(missionBackgroundView)
-        missionBackgroundView.snp.makeConstraints {
-            $0.top.equalTo(periodLabel.snp.bottom).offset(31)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.height.equalTo(100)
-        }
-        
-        missionBackgroundView.addSubview(missionTitleLabel)
-        missionTitleLabel.snp.makeConstraints{
-            $0.top.equalTo(missionBackgroundView.snp.top).inset(12)
-            $0.centerX.equalTo(missionBackgroundView.snp.centerX)
-        }
-        
-        missionBackgroundView.addSubview(missionContentsLabel)
-        missionContentsLabel.snp.makeConstraints{
-            $0.centerY.equalTo(missionTitleLabel.snp.bottom).offset(30)
-            $0.centerX.equalTo(missionBackgroundView.snp.centerX)
-            $0.leading.trailing.equalTo(missionBackgroundView).inset(12)
-        }
-
-        view.addSubview(informationTitleLabel)
-        informationTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(missionBackgroundView.snp.bottom).offset(44)
-            $0.leading.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-        }
-        
-        view.addSubview(manitteeBackView)
-        manitteeBackView.snp.makeConstraints {
-            $0.top.equalTo(informationTitleLabel.snp.bottom).offset(31)
-            $0.leading.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.trailing.equalTo(view.snp.centerX).offset(-14)
-            $0.height.equalTo((UIScreen.main.bounds.width-28-40)/2)
-        }
-        
-        manitteeBackView.addSubview(manitteeImageView)
-        manitteeImageView.snp.makeConstraints {
-            $0.top.equalTo(manitteeBackView.snp.top).inset(16)
-            $0.centerX.equalTo(manitteeBackView)
-            $0.width.height.equalTo(99)
-        }
-        
-        manitteeBackView.addSubview(manitteeIconView)
-        manitteeIconView.snp.makeConstraints {
-            $0.centerX.equalTo(manitteeImageView)
-            $0.centerY.equalTo(manitteeImageView.snp.centerY)
-            $0.width.height.equalTo(90)
-        }
-        
-        manitteeBackView.addSubview(manitteeLabel)
-        manitteeLabel.snp.makeConstraints {
-            $0.bottom.equalTo(manitteeBackView.snp.bottom).inset(15)
-            $0.centerX.equalTo(manitteeBackView)
-        }
-        
-        manitteeBackView.addSubview(manitteeAnimationLabel)
-        manitteeAnimationLabel.snp.makeConstraints {
-            $0.bottom.equalTo(manitteeBackView.snp.bottom).inset(15)
-            $0.centerX.equalTo(manitteeBackView)
-        }
-        
-        view.addSubview(listBackView)
-        listBackView.snp.makeConstraints {
-            $0.top.equalTo(informationTitleLabel.snp.bottom).offset(31)
-            $0.leading.equalTo(view.snp.centerX).offset(14)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.height.equalTo((UIScreen.main.bounds.width-28-40)/2)
-        }
-        
-        listBackView.addSubview(listImageView)
-        listImageView.snp.makeConstraints {
-            $0.top.equalTo(listBackView.snp.top).inset(16)
-            $0.centerX.equalTo(listBackView)
-            $0.width.height.equalTo(99)
-        }
-
-        listBackView.addSubview(listIconView)
-        listIconView.snp.makeConstraints {
-            $0.centerX.equalTo(listImageView)
-            $0.centerY.equalTo(listImageView.snp.centerY)
-            $0.width.height.equalTo(80)
-        }
-        
-        listBackView.addSubview(listLabel)
-        listLabel.snp.makeConstraints {
-            $0.bottom.equalTo(listBackView.snp.bottom).inset(15)
-            $0.centerX.equalTo(listBackView)
-        }
-        
-        view.addSubview(letterBoxButton)
-        letterBoxButton.snp.makeConstraints {
-            $0.top.equalTo(manitteeBackView.snp.bottom).offset(25)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.height.equalTo(80)
-        }
-        
-        view.addSubview(manittoMemoryButton)
-        manittoMemoryButton.snp.makeConstraints {
-            $0.top.equalTo(letterBoxButton.snp.bottom).offset(18)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(Size.leadingTrailingPadding)
-            $0.height.equalTo(80)
-        }
-        
-        view.addSubview(manittoOpenButtonShadowView)
-        manittoOpenButtonShadowView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(7)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(60)
-        }
-        
-        manittoOpenButtonShadowView.addSubview(manittoOpenButton)
-        manittoOpenButton.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        view.addSubview(manitiRealIconView)
-        manitiRealIconView.snp.makeConstraints {
-            $0.top.equalTo(manitteeIconView.snp.top)
-            $0.trailing.equalTo(manitteeIconView.snp.trailing)
-            $0.leading.equalTo(manitteeIconView.snp.leading)
-            $0.bottom.equalTo(manitteeIconView.snp.bottom)
-        }
-
-        view.addSubview(badgeLabel)
-        badgeLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview().offset(35)
-            $0.centerY.equalTo(letterBoxButton).offset(-10)
-            $0.width.height.equalTo(30)
-        }
-
-        self.view.addSubview(self.guideView)
-        self.guideView.snp.makeConstraints {
-            $0.top.equalTo(self.missionBackgroundView.snp.top)
-            $0.trailing.equalTo(self.missionBackgroundView.snp.trailing)
-        }
-        self.guideView.setupGuideViewLayout()
-    }
-    
-    override func setupNavigationBar() {
-        super.setupNavigationBar()
-        let rightItem = makeBarButtonItem(with: exitButton)
-        navigationItem.rightBarButtonItem = rightItem
-    }
-
-    override func endEditingView() {
-        self.guideView.didTapAroundToHideGuideView()
     }
     
     // MARK: - func
+    
+    private func configureDelegation() {
+        self.detailingView.configureDelegation(self)
+    }
+    
+    private func configureNavigationController() {
+        guard let navigationController = self.navigationController else { return }
+        self.detailingView.configureNavigationItem(navigationController)
+    }
     
     private func setupLargeTitleToOriginal() {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.navigationItem.largeTitleDisplayMode = .never
     }
-    
-    private func setupProcessingUI() {
-        missionBackgroundView.makeBorderLayer(color: .subOrange)
-        statusLabel.text = TextLiteral.doing
-        statusLabel.backgroundColor = .mainRed
-        manittoMemoryButton.isHidden = true
-        exitButton.isHidden = true
-    }
-    
-    private func setupPostUI() {
-        missionBackgroundView.makeBorderLayer(color: .darkGrey001)
-        statusLabel.text = TextLiteral.done
-        statusLabel.backgroundColor = .grey002
-        manittoMemoryButton.isHidden = false
-        exitButton.isHidden = false
-        missionContentsLabel.attributedText = NSAttributedString(string: TextLiteral.detailIngViewControllerDoneMissionText)
-    }
-
-    private func setupManittoOpenButton(date: String) {
-        guard let endDate = date.stringToDateYYYY() else { return }
-        manittoOpenButtonShadowView.isHidden = !(endDate.isOpenManitto)
-    }
-    
-    private func setupBadge(count: Int) {
-        if count > 0 {
-            badgeLabel.isHidden = false
-            badgeLabel.countLabel.text = String(count)
-        } else {
-            badgeLabel.isHidden = true
-        }
-    }
-    
+        
     private func openManittee(manitteeName: String) {
         let viewController = SelectManitteeViewController(roomId: self.roomId, manitteeNickname: manitteeName)
         viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
     }
-    
-    private func setupExitButton(admin: Bool) {
-        if admin {
-            let menu = UIMenu(options: [], children: [
-                UIAction(title: TextLiteral.detailWaitViewControllerDeleteRoom, handler: { [weak self] _ in
-                    self?.makeRequestAlert(title: TextLiteral.detailIngViewControllerDoneExitAlertAdminTitle, message: TextLiteral.detailIngViewControllerDoneExitAlertAdmin, okAction: { _ in
-                        self?.requestDeleteRoom()
-                    })
-                })
-            ])
-            exitButton.menu = menu
-        } else {
-            let menu = UIMenu(options: [], children: [
-                UIAction(title: TextLiteral.detailWaitViewControllerLeaveRoom, handler: { [weak self] _ in
-                    self?.makeRequestAlert(title: TextLiteral.detailIngViewControllerDoneExitAlertTitle, message: TextLiteral.detailIngViewControllerDoneExitAlertMessage, okAction: { _ in
-                        self?.requestExitRoom()
-                    })
-                })
-            ])
-            exitButton.menu = menu
-        }
-    }
-    
+        
     func pushNavigationAfterRequestRoomInfo() {
         Task {
             do {
@@ -503,32 +102,7 @@ final class DetailingViewController: BaseViewController {
             }
         }
     }
-  
-    // MARK: - selector
-    
-    @objc
-    private func didTappedManittee() {
-        if !isTappedManittee {
-            self.isTappedManittee = true
-            UIView.animate(withDuration: 1.0) {
-                self.toggledManitteeAnimation(self.isTappedManittee)
-            } completion: { _ in
-                UIView.animate(withDuration: 1.0, delay: 0.5) {
-                    self.toggledManitteeAnimation(!self.isTappedManittee)
-                } completion: { _ in
-                    self.isTappedManittee = false
-                }
-            }
-        }
-    }
-    
-    private func toggledManitteeAnimation(_ value: Bool) {
-        manitteeLabel.alpha = value ? 0 : 1
-        manitteeIconView.alpha = value ? 0 : 1
-        manitiRealIconView.alpha = value ? 1 : 0
-        manitteeAnimationLabel.alpha = value ? 1 : 0
-    }
-    
+      
     // FIXME: - 추후 PR 때, friendslistViewController codebase로 만들 예정
     @objc
     private func pushFriendListViewController(_ gesture: UITapGestureRecognizer) {
@@ -541,46 +115,12 @@ final class DetailingViewController: BaseViewController {
     
     // MARK: - DetailStarting API
    
-    private func requestRoomInfo() {
+    private func requestRoomInfo(completionHandler: @escaping ((Result<Room, NetworkError>) -> Void)) {
         Task {
             do {
                 let data = try await detailIngService.requestStartingRoomInfo(roomId: roomId)
                 if let info = data {
-                    guard let state = data?.roomInformation?.state,
-                          let title = info.roomInformation?.title,
-                          let startDate = info.roomInformation?.startDate,
-                          let endDate = info.roomInformation?.endDate,
-                          let manittee = info.manittee?.nickname,
-                          let admin = info.admin,
-                          let badgeCount = info.messages?.count
-                    else { return }
-                    
-                    roomType = RoomType.init(rawValue: state) ?? .PROCESSING
-                    missionId = info.mission?.id?.description ?? ""
-                    
-                    DispatchQueue.main.async {
-                        self.titleLabel.text = title
-                        self.periodLabel.text = "\(startDate.subStringToDate()) ~ \(endDate.subStringToDate())"
-                        self.manitteeAnimationLabel.text = manittee
-                        self.setupBadge(count: badgeCount)
-                        
-                        if self.roomType == .PROCESSING {
-                            self.setupProcessingUI()
-                            guard let missionContent = info.mission?.content,
-                                  let didView = info.didViewRoulette,
-                                  let manittoNickname = info.manitto?.nickname
-                            else { return }
-                            self.missionContentsLabel.attributedText = NSAttributedString(string: missionContent)
-                            self.manittoNickname = manittoNickname
-                            if !didView && !admin {
-                                self.openManittee(manitteeName: manittee)
-                            }
-                            self.setupManittoOpenButton(date: endDate)
-                        } else {
-                            self.setupPostUI()
-                            self.setupExitButton(admin: admin)
-                        }
-                    }
+                    completionHandler(.success(info))
                 }
             } catch NetworkError.serverError {
                 print("server Error")
@@ -628,3 +168,33 @@ final class DetailingViewController: BaseViewController {
     }
 }
 
+extension DetailingViewController: DetailingDelegate {
+    
+    func listBackDidTap() {
+        print("")
+    }
+    
+    func letterBoxDidTap() {
+        print("")
+    }
+    
+    func manittoMemoryButtonDidTap() {
+        print("")
+    }
+    
+    func manittoOpenButtonDidTap() {
+        print("")
+    }
+    
+    func deleteButtonDidTap() {
+        print("")
+    }
+    
+    func leaveButtonDidTap() {
+        print("")
+    }
+    
+    func didNotShowManitteeView(manitteeName: String) {
+        self.openManittee(manitteeName: manitteeName)
+    }
+}

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -177,8 +177,15 @@ extension DetailingViewController: DetailingDelegate {
         self.pushFriendListViewController()
     }
     
-    func letterBoxDidTap() {
-        print("")
+    func letterBoxDidTap(type: String,
+                         mission: String,
+                         missionId: String) {
+          let letterViewController = LetterViewController(roomState: type,
+                                                          roomId: self.roomId,
+                                                          mission: mission,
+                                                          missionId: missionId,
+                                                          entryPoint: .detail)
+          self.navigationController?.pushViewController(letterViewController, animated: true)
     }
     
     func manittoMemoryButtonDidTap() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -172,6 +172,15 @@ final class DetailingViewController: BaseViewController {
 }
 
 extension DetailingViewController: DetailingDelegate {
+    func editMissionButtonDidTap() {
+        self.makeActionSheet(title: TextLiteral.detailIngViewControllerMissionEditTitle,
+                             actionTitles: [
+                                TextLiteral.detailIngViewControllerSelfEditMissionTitle,
+                                TextLiteral.detailIngViewControllerResetMissionTitle,
+                                TextLiteral.cancel],
+                             actionStyle: [.default, .default, .cancel], actions: [nil, nil, nil])
+    }
+    
     func listBackDidTap() {
         self.pushFriendListViewController()
     }

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -172,7 +172,6 @@ final class DetailingViewController: BaseViewController {
 }
 
 extension DetailingViewController: DetailingDelegate {
-    
     func listBackDidTap() {
         self.pushFriendListViewController()
     }
@@ -189,11 +188,15 @@ extension DetailingViewController: DetailingDelegate {
     }
     
     func manittoMemoryButtonDidTap() {
-        print("")
+        let viewController = MemoryViewController(roomId: self.roomId)
+        self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func manittoOpenButtonDidTap() {
-        print("")
+    func manittoOpenButtonDidTap(nickname: String) {
+        let viewController = OpenManittoViewController(roomId: self.roomId, manittoNickname: nickname)
+        viewController.modalTransitionStyle = .crossDissolve
+        viewController.modalPresentationStyle = .fullScreen
+        self.present(viewController, animated: true)
     }
     
     func deleteButtonDidTap() {

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -11,12 +11,14 @@ import SnapKit
 
 final class DetailingViewController: BaseViewController {
     
+    // MARK: - property
+    
     private let detailIngService: DetailIngAPI = DetailIngAPI(apiService: APIService())
     private let detailDoneService: DetailDoneAPI = DetailDoneAPI(apiService: APIService())
     private let roomId: String
     private var missionId: String = ""
-
-    // MARK: - property
+    
+    // MARK: - component
     
     private let detailingView: DetailingView = DetailingView()
     
@@ -27,6 +29,7 @@ final class DetailingViewController: BaseViewController {
         super.init()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -49,7 +52,7 @@ final class DetailingViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setupLargeTitleToOriginal()
+        self.setupLargeTitleToOriginal()
         self.requestRoomInfo() { [weak self] result in
             switch result {
             case .success(let roomInformation):
@@ -72,21 +75,21 @@ final class DetailingViewController: BaseViewController {
     }
     
     private func setupLargeTitleToOriginal() {
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.navigationItem.largeTitleDisplayMode = .never
+        self.navigationController?.navigationBar.prefersLargeTitles = false
+        self.navigationController?.navigationItem.largeTitleDisplayMode = .never
     }
         
     private func openManittee(manitteeName: String) {
         let viewController = SelectManitteeViewController(roomId: self.roomId, manitteeNickname: manitteeName)
         viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: true)
+        self.present(viewController, animated: true)
     }
         
     func pushNavigationAfterRequestRoomInfo() {
         Task {
             do {
-                let data = try await detailIngService.requestStartingRoomInfo(roomId: roomId)
+                let data = try await detailIngService.requestStartingRoomInfo(roomId: self.roomId)
                 if let info = data {
                     guard let state = info.roomInformation?.state,
                           let mission = info.mission?.content,
@@ -102,8 +105,7 @@ final class DetailingViewController: BaseViewController {
             }
         }
     }
-      
-    // FIXME: - 추후 PR 때, friendslistViewController codebase로 만들 예정
+    
     @objc
     private func pushFriendListViewController(_ gesture: UITapGestureRecognizer) {
         let storyboard = UIStoryboard(name: "DetailIng", bundle: nil)

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -429,23 +429,23 @@ final class DetailingView: UIView {
                     self?.delegate?.deleteButtonDidTap()
                 })
             ])
-            exitButton.menu = menu
+            self.exitButton.menu = menu
         } else {
             let menu = UIMenu(options: [], children: [
                 UIAction(title: TextLiteral.detailWaitViewControllerLeaveRoom, handler: { [weak self] _ in
                     self?.delegate?.leaveButtonDidTap()
                 })
             ])
-            exitButton.menu = menu
+            self.exitButton.menu = menu
         }
     }
     
     private func setupBadge(count: Int) {
         if count > 0 {
-            badgeLabel.isHidden = false
-            badgeLabel.countLabel.text = String(count)
+            self.badgeLabel.isHidden = false
+            self.badgeLabel.countLabel.text = String(count)
         } else {
-            badgeLabel.isHidden = true
+            self.badgeLabel.isHidden = true
         }
     }
     
@@ -472,10 +472,10 @@ final class DetailingView: UIView {
     }
     
     private func toggledManitteeAnimation(_ value: Bool) {
-        manitteeLabel.alpha = value ? 0 : 1
-        manitteeIconView.alpha = value ? 0 : 1
-        manitiRealIconView.alpha = value ? 1 : 0
-        manitteeAnimationLabel.alpha = value ? 1 : 0
+        self.manitteeLabel.alpha = value ? 0 : 1
+        self.manitteeIconView.alpha = value ? 0 : 1
+        self.manitiRealIconView.alpha = value ? 1 : 0
+        self.manitteeAnimationLabel.alpha = value ? 1 : 0
     }
     
     // MARK: - selector

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -431,7 +431,7 @@ final class DetailingView: UIView {
             self.periodLabel.text = "\(startDate.subStringToDate()) ~ \(endDate.subStringToDate())"
             self.manitteeAnimationLabel.text = manittee
             self.setupBadge(count: badgeCount)
-            
+            self.updateMissionEditButton(admin, type: self.roomType)
             if self.roomType == .PROCESSING {
                 self.setupProcessingUI()
                 guard let missionContent = room.mission?.content,
@@ -505,6 +505,15 @@ final class DetailingView: UIView {
         self.manitteeIconView.alpha = value ? 0 : 1
         self.manitiRealIconView.alpha = value ? 1 : 0
         self.manitteeAnimationLabel.alpha = value ? 1 : 0
+    }
+    
+    private func updateMissionEditButton(_ isAdmin: Bool, type: RoomType) {
+        if type == .POST {
+            self.pencilButton.isHidden = true
+        }
+        if !isAdmin {
+            self.pencilButton.isHidden = true
+        }
     }
     
     // MARK: - selector

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -15,7 +15,7 @@ protocol DetailingDelegate: AnyObject {
                          mission: String,
                          missionId: String)
     func manittoMemoryButtonDidTap()
-    func manittoOpenButtonDidTap()
+    func manittoOpenButtonDidTap(nickname: String)
     func deleteButtonDidTap()
     func leaveButtonDidTap()
     func didNotShowManitteeView(manitteeName: String)
@@ -32,6 +32,7 @@ final class DetailingView: UIView {
     
     private var isTappedManittee: Bool = false
     private var missionId: String = ""
+    private var manittoNickname: String = ""
     private var roomType: RoomType = .PROCESSING
     private weak var delegate: DetailingDelegate?
     
@@ -193,7 +194,8 @@ final class DetailingView: UIView {
     private lazy var manittoOpenButton: MainButton = {
         let button = MainButton()
         let action = UIAction { [weak self] _ in
-            self?.delegate?.manittoOpenButtonDidTap()
+            guard let manittoNickname = self?.manittoNickname else { return }
+            self?.delegate?.manittoOpenButtonDidTap(nickname: manittoNickname)
         }
         button.addAction(action, for: .touchUpInside)
         button.title = TextLiteral.detailIngViewControllerManitoOpenButton
@@ -415,9 +417,11 @@ final class DetailingView: UIView {
             if self.roomType == .PROCESSING {
                 self.setupProcessingUI()
                 guard let missionContent = room.mission?.content,
-                      let didView = room.didViewRoulette
+                      let didView = room.didViewRoulette,
+                      let manittoNickname = room.manitto?.nickname
                 else { return }
                 self.missionContentsLabel.attributedText = NSAttributedString(string: missionContent)
+                self.manittoNickname = manittoNickname
                 if !didView && !admin {
                     self.delegate?.didNotShowManitteeView(manitteeName: manittee)
                 }

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -1,0 +1,503 @@
+//
+//  DetailingView.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/19.
+//
+
+import UIKit
+
+import SnapKit
+
+protocol DetailingDelegate: AnyObject {
+    func listBackDidTap()
+    func letterBoxDidTap()
+    func manittoMemoryButtonDidTap()
+    func manittoOpenButtonDidTap()
+    func deleteButtonDidTap()
+    func leaveButtonDidTap()
+    func didNotShowManitteeView(manitteeName: String)
+}
+
+final class DetailingView: UIView {
+    
+    private enum RoomType: String {
+        case PROCESSING
+        case POST
+    }
+    
+    // MARK: - property
+    
+    private var isTappedManittee: Bool = false
+    private var missionId: String = ""
+    private var roomType: RoomType = .PROCESSING
+    private weak var delegate: DetailingDelegate?
+    
+    // MARK: - component
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 34)
+        return label
+    }()
+    private let periodLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .grey002
+        label.font = .font(.regular, ofSize: 16)
+        return label
+    }()
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.layer.masksToBounds = true
+        label.layer.cornerRadius = 11
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 13)
+        label.textAlignment = .center
+        return label
+    }()
+    private let missionBackgroundView: UIView = {
+        var view = UIView()
+        view.backgroundColor = .darkGrey004
+        return view
+    }()
+    private let missionTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.individualMissionViewTitleLabel
+        label.textColor = .grey002
+        label.font = .font(.regular, ofSize: 14)
+        return label
+    }()
+    private let missionContentsLabel: UILabel = {
+        let label = UILabel()
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        let attributedText = NSAttributedString(string: "", attributes: [.paragraphStyle: paragraphStyle])
+        label.attributedText = attributedText
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 18)
+        return label
+    }()
+    private let informationTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.detailIngViewControllerDetailInformatioin
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 16)
+        return label
+    }()
+    private lazy var manitteeBackView: UIView = {
+        let view = UIView()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.didTappedManittee))
+        view.addGestureRecognizer(tapGesture)
+        view.backgroundColor = .darkGrey002
+        view.makeBorderLayer(color: .white)
+        return view
+    }()
+    private let manitteeImageView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .subOrange
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.grey005.cgColor
+        view.layer.cornerRadius = 49.5
+        return view
+    }()
+    private let manitteeIconView = UIImageView(image: ImageLiterals.icManiTti)
+    private let manitteeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "\(UserDefaultStorage.nickname)의 마니띠"
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 15)
+        return label
+    }()
+    private lazy var listBackView: UIView = {
+        let view = UIView()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.didTappedListBack))
+        view.addGestureRecognizer(tapGesture)
+        view.backgroundColor = .darkGrey002
+        view.makeBorderLayer(color: .white)
+        return view
+    }()
+    private let listImageView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .subPink
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.grey005.cgColor
+        view.layer.cornerRadius = 49.5
+        return view
+    }()
+    private let listIconView = UIImageView(image: ImageLiterals.icList)
+    private let listLabel: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.togetherFriend
+        label.textColor = .white
+        label.font = .font(.regular, ofSize: 15)
+        return label
+    }()
+    private lazy var letterBoxButton: UIButton = {
+        let button = UIButton(type: .system)
+        let action = UIAction { [weak self] _ in
+            self?.delegate?.letterBoxDidTap()
+        }
+        button.addAction(action, for: .touchUpInside)
+        button.setTitle(TextLiteral.letterViewControllerTitle, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .font(.regular, ofSize: 15)
+        button.backgroundColor = .darkGrey002
+        button.makeBorderLayer(color: .white)
+        return button
+    }()
+    private lazy var manittoMemoryButton: UIButton = {
+        let button = UIButton(type: .system)
+        let action = UIAction { [weak self] _ in
+            self?.delegate?.manittoMemoryButtonDidTap()
+        }
+        button.addAction(action, for: .touchUpInside)
+        button.setTitle(TextLiteral.memoryViewControllerTitleLabel, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .font(.regular, ofSize: 15)
+        button.backgroundColor = .darkGrey002
+        button.makeBorderLayer(color: .white)
+        return button
+    }()
+    private let manitteeAnimationLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.alpha = 0
+        label.font = .font(.regular, ofSize: 15)
+        return label
+    }()
+    private let manitiRealIconView: UIImageView = {
+        let imageView = UIImageView(image: ImageLiterals.imgMa)
+        imageView.alpha = 0
+        return imageView
+    }()
+    private let manittoOpenButtonShadowView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .mainRed
+        view.layer.masksToBounds = false
+        view.layer.cornerRadius = 30
+        view.makeShadow(color: .shadowRed, opacity: 1.0, offset: CGSize(width: 0, height: 6), radius: 1)
+        view.isHidden = true
+        return view
+    }()
+    // FIXME: - 마니또 공개 API 확실히 하기
+    private lazy var manittoOpenButton: MainButton = {
+        let button = MainButton()
+        let action = UIAction { [weak self] _ in
+            self?.delegate?.manittoOpenButtonDidTap()
+        }
+        button.addAction(action, for: .touchUpInside)
+        button.title = TextLiteral.detailIngViewControllerManitoOpenButton
+        return button
+    }()
+    private let badgeLabel: LetterCountBadgeView = {
+        let label = LetterCountBadgeView()
+        label.layer.cornerRadius = 15
+        label.isHidden = true
+        return label
+    }()
+    private let exitButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.icMore, for: .normal)
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }()
+    private let guideView: GuideView = GuideView(type: .detailing)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - func
+    
+    private func setupLayout() {
+        self.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(100)
+            $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+        }
+        
+        self.addSubview(self.periodLabel)
+        self.periodLabel.snp.makeConstraints {
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(12)
+            $0.leading.equalToSuperview().inset(24)
+        }
+        
+        self.addSubview(self.statusLabel)
+        self.statusLabel.snp.makeConstraints {
+            $0.centerY.equalTo(self.titleLabel.snp.centerY)
+            $0.leading.equalTo(self.titleLabel.snp.trailing).offset(6)
+            $0.width.equalTo(67)
+            $0.height.equalTo(23)
+        }
+
+        self.addSubview(self.missionBackgroundView)
+        self.missionBackgroundView.snp.makeConstraints {
+            $0.top.equalTo(self.periodLabel.snp.bottom).offset(31)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.height.equalTo(100)
+        }
+        
+        self.missionBackgroundView.addSubview(self.missionTitleLabel)
+        self.missionTitleLabel.snp.makeConstraints{
+            $0.top.equalTo(self.missionBackgroundView.snp.top).inset(12)
+            $0.centerX.equalTo(self.missionBackgroundView.snp.centerX)
+        }
+        
+        self.missionBackgroundView.addSubview(self.missionContentsLabel)
+        self.missionContentsLabel.snp.makeConstraints{
+            $0.centerY.equalTo(self.missionTitleLabel.snp.bottom).offset(30)
+            $0.centerX.equalTo(self.missionBackgroundView.snp.centerX)
+            $0.leading.trailing.equalTo(self.missionBackgroundView).inset(12)
+        }
+
+        self.addSubview(self.informationTitleLabel)
+        self.informationTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(self.missionBackgroundView.snp.bottom).offset(44)
+            $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+        }
+        
+        self.addSubview(self.manitteeBackView)
+        self.manitteeBackView.snp.makeConstraints {
+            $0.top.equalTo(self.informationTitleLabel.snp.bottom).offset(31)
+            $0.leading.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.trailing.equalTo(self.snp.centerX).offset(-14)
+            $0.height.equalTo((UIScreen.main.bounds.width - 28 - 40) / 2)
+        }
+        
+        self.manitteeBackView.addSubview(self.manitteeImageView)
+        self.manitteeImageView.snp.makeConstraints {
+            $0.top.equalTo(self.manitteeBackView.snp.top).inset(16)
+            $0.centerX.equalTo(self.manitteeBackView)
+            $0.width.height.equalTo(99)
+        }
+        
+        self.manitteeBackView.addSubview(self.manitteeIconView)
+        self.manitteeIconView.snp.makeConstraints {
+            $0.centerX.equalTo(self.manitteeImageView)
+            $0.centerY.equalTo(self.manitteeImageView.snp.centerY)
+            $0.width.height.equalTo(90)
+        }
+        
+        self.manitteeBackView.addSubview(self.manitteeLabel)
+        self.manitteeLabel.snp.makeConstraints {
+            $0.bottom.equalTo(self.manitteeBackView.snp.bottom).inset(15)
+            $0.centerX.equalTo(self.manitteeBackView)
+        }
+        
+        self.manitteeBackView.addSubview(self.manitteeAnimationLabel)
+        self.manitteeAnimationLabel.snp.makeConstraints {
+            $0.bottom.equalTo(self.manitteeBackView.snp.bottom).inset(15)
+            $0.centerX.equalTo(self.manitteeBackView)
+        }
+        
+        self.addSubview(self.listBackView)
+        self.listBackView.snp.makeConstraints {
+            $0.top.equalTo(self.informationTitleLabel.snp.bottom).offset(31)
+            $0.leading.equalTo(self.snp.centerX).offset(14)
+            $0.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.height.equalTo((UIScreen.main.bounds.width - 28 - 40) / 2)
+        }
+        
+        self.listBackView.addSubview(self.listImageView)
+        self.listImageView.snp.makeConstraints {
+            $0.top.equalTo(self.listBackView.snp.top).inset(16)
+            $0.centerX.equalTo(self.listBackView)
+            $0.width.height.equalTo(99)
+        }
+
+        self.listBackView.addSubview(self.listIconView)
+        self.listIconView.snp.makeConstraints {
+            $0.centerX.equalTo(self.listImageView)
+            $0.centerY.equalTo(self.listImageView.snp.centerY)
+            $0.width.height.equalTo(80)
+        }
+        
+        self.listBackView.addSubview(self.listLabel)
+        self.listLabel.snp.makeConstraints {
+            $0.bottom.equalTo(self.listBackView.snp.bottom).inset(15)
+            $0.centerX.equalTo(self.listBackView)
+        }
+        
+        self.addSubview(self.letterBoxButton)
+        self.letterBoxButton.snp.makeConstraints {
+            $0.top.equalTo(self.manitteeBackView.snp.bottom).offset(25)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.height.equalTo(80)
+        }
+        
+        self.addSubview(self.manittoMemoryButton)
+        self.manittoMemoryButton.snp.makeConstraints {
+            $0.top.equalTo(self.letterBoxButton.snp.bottom).offset(18)
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.height.equalTo(80)
+        }
+        
+        self.addSubview(self.manittoOpenButtonShadowView)
+        self.manittoOpenButtonShadowView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
+            $0.bottom.equalToSuperview().inset(7)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(60)
+        }
+        
+        self.manittoOpenButtonShadowView.addSubview(self.manittoOpenButton)
+        self.manittoOpenButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        self.addSubview(self.manitiRealIconView)
+        self.manitiRealIconView.snp.makeConstraints {
+            $0.top.equalTo(self.manitteeIconView.snp.top)
+            $0.trailing.equalTo(self.manitteeIconView.snp.trailing)
+            $0.leading.equalTo(self.manitteeIconView.snp.leading)
+            $0.bottom.equalTo(self.manitteeIconView.snp.bottom)
+        }
+
+        self.addSubview(self.badgeLabel)
+        self.badgeLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview().offset(35)
+            $0.centerY.equalTo(letterBoxButton).offset(-10)
+            $0.width.height.equalTo(30)
+        }
+
+        self.addSubview(self.guideView)
+        self.guideView.snp.makeConstraints {
+            $0.top.equalTo(self.missionBackgroundView.snp.top)
+            $0.trailing.equalTo(self.missionBackgroundView.snp.trailing)
+        }
+        self.guideView.setupGuideViewLayout()
+    }
+    
+    func configureDelegation(_ delegate: DetailingDelegate) {
+        self.delegate = delegate
+    }
+    
+    func configureNavigationItem(_ navigationController: UINavigationController) {
+        let navigationItem = navigationController.topViewController?.navigationItem
+        let exitButton = UIBarButtonItem(customView: self.exitButton)
+        
+        navigationItem?.rightBarButtonItem = exitButton
+    }
+    
+    func updateDetailingView(room: Room) {
+        guard let state = room.roomInformation?.state,
+              let title = room.roomInformation?.title,
+              let startDate = room.roomInformation?.startDate,
+              let endDate = room.roomInformation?.endDate,
+              let manittee = room.manittee?.nickname,
+              let admin = room.admin,
+              let badgeCount = room.messages?.count
+        else { return }
+        self.roomType = RoomType.init(rawValue: state) ?? .PROCESSING
+        self.missionId = room.mission?.id?.description ?? ""
+        DispatchQueue.main.async {
+            self.titleLabel.text = title
+            self.periodLabel.text = "\(startDate.subStringToDate()) ~ \(endDate.subStringToDate())"
+            self.manitteeAnimationLabel.text = manittee
+            self.setupBadge(count: badgeCount)
+            
+            if self.roomType == .PROCESSING {
+                self.setupProcessingUI()
+                guard let missionContent = room.mission?.content,
+                      let didView = room.didViewRoulette
+                else { return }
+                self.missionContentsLabel.attributedText = NSAttributedString(string: missionContent)
+                if !didView && !admin {
+                    self.delegate?.didNotShowManitteeView(manitteeName: manittee)
+                }
+                self.setupManittoOpenButton(date: endDate)
+            } else {
+                self.setupPostUI()
+                self.setupExitButton(admin: admin)
+            }
+        }
+    }
+    
+    private func setupExitButton(admin: Bool) {
+        if admin {
+            let menu = UIMenu(options: [], children: [
+                UIAction(title: TextLiteral.detailWaitViewControllerDeleteRoom, handler: { [weak self] _ in
+                    self?.delegate?.deleteButtonDidTap()
+                })
+            ])
+            exitButton.menu = menu
+        } else {
+            let menu = UIMenu(options: [], children: [
+                UIAction(title: TextLiteral.detailWaitViewControllerLeaveRoom, handler: { [weak self] _ in
+                    self?.delegate?.leaveButtonDidTap()
+                })
+            ])
+            exitButton.menu = menu
+        }
+    }
+    
+    private func setupBadge(count: Int) {
+        if count > 0 {
+            badgeLabel.isHidden = false
+            badgeLabel.countLabel.text = String(count)
+        } else {
+            badgeLabel.isHidden = true
+        }
+    }
+    
+    private func setupProcessingUI() {
+        self.missionBackgroundView.makeBorderLayer(color: .subOrange)
+        self.statusLabel.text = TextLiteral.doing
+        self.statusLabel.backgroundColor = .mainRed
+        self.manittoMemoryButton.isHidden = true
+        self.exitButton.isHidden = true
+    }
+    
+    private func setupPostUI() {
+        self.missionBackgroundView.makeBorderLayer(color: .darkGrey001)
+        self.statusLabel.text = TextLiteral.done
+        self.statusLabel.backgroundColor = .grey002
+        self.manittoMemoryButton.isHidden = false
+        self.exitButton.isHidden = false
+        self.missionContentsLabel.attributedText = NSAttributedString(string: TextLiteral.detailIngViewControllerDoneMissionText)
+    }
+    
+    private func setupManittoOpenButton(date: String) {
+        guard let endDate = date.stringToDateYYYY() else { return }
+        self.manittoOpenButtonShadowView.isHidden = !(endDate.isOpenManitto)
+    }
+    
+    private func toggledManitteeAnimation(_ value: Bool) {
+        manitteeLabel.alpha = value ? 0 : 1
+        manitteeIconView.alpha = value ? 0 : 1
+        manitiRealIconView.alpha = value ? 1 : 0
+        manitteeAnimationLabel.alpha = value ? 1 : 0
+    }
+    
+    // MARK: - selector
+    
+    @objc
+    private func didTappedListBack() {
+        self.delegate?.listBackDidTap()
+    }
+    
+    @objc
+    private func didTappedManittee() {
+        if !isTappedManittee {
+            self.isTappedManittee = true
+            UIView.animate(withDuration: 1.0) {
+                self.toggledManitteeAnimation(self.isTappedManittee)
+            } completion: { _ in
+                UIView.animate(withDuration: 1.0, delay: 0.5) {
+                    self.toggledManitteeAnimation(!self.isTappedManittee)
+                } completion: { _ in
+                    self.isTappedManittee = false
+                }
+            }
+        }
+    }
+}

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -10,6 +10,7 @@ import UIKit
 import SnapKit
 
 protocol DetailingDelegate: AnyObject {
+    func editMissionButtonDidTap()
     func listBackDidTap()
     func letterBoxDidTap(type: String,
                          mission: String,
@@ -71,10 +72,10 @@ final class DetailingView: UIView {
         label.font = .font(.regular, ofSize: 14)
         return label
     }()
-    private let pencilButton: UIButton = {
+    private lazy var pencilButton: UIButton = {
         let button = UIButton(type: .system)
-        let action = UIAction { _ in
-            print("pencil")
+        let action = UIAction { [weak self] _ in
+            self?.delegate?.editMissionButtonDidTap()
         }
         button.addAction(action, for: .touchUpInside)
         button.setImage(ImageLiterals.icPencil, for: .normal)

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -71,6 +71,15 @@ final class DetailingView: UIView {
         label.font = .font(.regular, ofSize: 14)
         return label
     }()
+    private let pencilButton: UIButton = {
+        let button = UIButton(type: .system)
+        let action = UIAction { _ in
+            print("pencil")
+        }
+        button.addAction(action, for: .touchUpInside)
+        button.setImage(ImageLiterals.icPencil, for: .normal)
+        return button
+    }()
     private let missionContentsLabel: UILabel = {
         let label = UILabel()
         let paragraphStyle = NSMutableParagraphStyle()
@@ -384,6 +393,13 @@ final class DetailingView: UIView {
             $0.trailing.equalTo(self.missionBackgroundView.snp.trailing)
         }
         self.guideView.setupGuideViewLayout()
+        
+        self.addSubview(self.pencilButton)
+        self.pencilButton.snp.makeConstraints {
+            $0.leading.equalTo(self.missionTitleLabel.snp.trailing).offset(-6)
+            $0.centerY.equalTo(self.missionTitleLabel.snp.centerY)
+            $0.width.height.equalTo(44)
+        }
     }
     
     func configureDelegation(_ delegate: DetailingDelegate) {

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 protocol DetailingDelegate: AnyObject {
-    func editMissionButtonDidTap()
+    func editMissionButtonDidTap(mission: String)
     func listBackDidTap()
     func letterBoxDidTap(type: String,
                          mission: String,
@@ -75,7 +75,8 @@ final class DetailingView: UIView {
     private lazy var pencilButton: UIButton = {
         let button = UIButton(type: .system)
         let action = UIAction { [weak self] _ in
-            self?.delegate?.editMissionButtonDidTap()
+            guard let mission = self?.missionContentsLabel.text else { return }
+            self?.delegate?.editMissionButtonDidTap(mission: mission)
         }
         button.addAction(action, for: .touchUpInside)
         button.setImage(ImageLiterals.icPencil, for: .normal)

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -11,7 +11,9 @@ import SnapKit
 
 protocol DetailingDelegate: AnyObject {
     func listBackDidTap()
-    func letterBoxDidTap()
+    func letterBoxDidTap(type: String,
+                         mission: String,
+                         missionId: String)
     func manittoMemoryButtonDidTap()
     func manittoOpenButtonDidTap()
     func deleteButtonDidTap()
@@ -138,7 +140,12 @@ final class DetailingView: UIView {
     private lazy var letterBoxButton: UIButton = {
         let button = UIButton(type: .system)
         let action = UIAction { [weak self] _ in
-            self?.delegate?.letterBoxDidTap()
+            guard let roomType = self?.roomType,
+                  let mission = self?.missionContentsLabel.text
+            else { return }
+            self?.delegate?.letterBoxDidTap(type: roomType.rawValue,
+                                            mission: mission,
+                                            missionId: self?.missionId ?? "")
         }
         button.addAction(action, for: .touchUpInside)
         button.setTitle(TextLiteral.letterViewControllerTitle, for: .normal)

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class MissionEditViewController: BaseViewController {
     
+    let mission: String
+    
     // MARK: - component
     
     private let backgroundView: UIView = {
@@ -21,6 +23,35 @@ final class MissionEditViewController: BaseViewController {
         view.backgroundColor = .darkGrey004
         return view
     }()
+    private lazy var missionTextField: UITextField = {
+        let textField = UITextField()
+        let attributes = [
+            NSAttributedString.Key.font : UIFont.font(.regular, ofSize: 18)
+        ]
+        textField.backgroundColor = .darkGrey002
+        textField.attributedPlaceholder = NSAttributedString(string: self.mission, attributes:attributes)
+        textField.font = .font(.regular, ofSize: 18)
+        textField.layer.cornerRadius = 10
+        textField.layer.masksToBounds = true
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.white.cgColor
+        textField.textAlignment = .center
+        textField.returnKeyType = .done
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.becomeFirstResponder()
+        return textField
+    }()
+    
+    init(mission: String) {
+        self.mission = mission
+        super.init()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - life cycle
     
@@ -40,6 +71,13 @@ final class MissionEditViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview()
             $0.centerY.equalToSuperview()
             $0.height.equalTo(120)
+        }
+        
+        self.view.addSubview(missionTextField)
+        self.missionTextField.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.center.equalToSuperview()
+            $0.height.equalTo(60)
         }
     }
     

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -58,22 +58,23 @@ final class MissionEditViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupGesture()
+        self.setupNotificationCenter()
     }
     
     override func configureUI() {
         super.configureUI()
+//        self.view.backgroundColor = .clear
         self.view.backgroundColor = .darkGrey001.withAlphaComponent(0.5)
     }
     
     override func setupLayout() {
         self.view.addSubview(self.backgroundView)
         self.backgroundView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.centerY.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(120)
         }
         
-        self.view.addSubview(missionTextField)
+        self.backgroundView.addSubview(missionTextField)
         self.missionTextField.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.center.equalToSuperview()
@@ -88,10 +89,29 @@ final class MissionEditViewController: BaseViewController {
         self.view.addGestureRecognizer(tapGesture)
     }
     
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
     // MARK: - selector
     
     @objc
     private func dismissViewController() {
         self.dismiss(animated: true)
+    }
+    
+    @objc private func keyboardWillShow(notification:NSNotification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.backgroundView.transform = CGAffineTransform(translationX: 0, y: -keyboardSize.height + 30)
+            })
+        }
+    }
+    
+    @objc private func keyboardWillHide(notification:NSNotification) {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.backgroundView.transform = .identity
+        })
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -1,0 +1,59 @@
+//
+//  MissionEditViewController.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/19.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MissionEditViewController: BaseViewController {
+    
+    // MARK: - component
+    
+    private let backgroundView: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 20
+        view.layer.maskedCorners = CACornerMask(arrayLiteral: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        view.backgroundColor = .darkGrey004
+        return view
+    }()
+    
+    // MARK: - life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setupGesture()
+    }
+    
+    override func configureUI() {
+        super.configureUI()
+        self.view.backgroundColor = .darkGrey001.withAlphaComponent(0.5)
+    }
+    
+    override func setupLayout() {
+        self.view.addSubview(self.backgroundView)
+        self.backgroundView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.height.equalTo(120)
+        }
+    }
+    
+    // MARK: - func
+    
+    private func setupGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissViewController))
+        self.view.addGestureRecognizer(tapGesture)
+    }
+    
+    // MARK: - selector
+    
+    @objc
+    private func dismissViewController() {
+        self.dismiss(animated: true)
+    }
+}

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -40,6 +40,7 @@ final class MissionEditViewController: BaseViewController {
         textField.autocorrectionType = .no
         textField.autocapitalizationType = .none
         textField.becomeFirstResponder()
+        textField.delegate = self
         return textField
     }()
     
@@ -63,7 +64,6 @@ final class MissionEditViewController: BaseViewController {
     
     override func configureUI() {
         super.configureUI()
-//        self.view.backgroundColor = .clear
         self.view.backgroundColor = .darkGrey001.withAlphaComponent(0.5)
     }
     
@@ -113,5 +113,13 @@ final class MissionEditViewController: BaseViewController {
         UIView.animate(withDuration: 0.2, animations: {
             self.backgroundView.transform = .identity
         })
+    }
+}
+
+extension MissionEditViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        self.missionTextField.endEditing(true)
+        self.dismiss(animated: true)
+        return true
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -118,6 +118,7 @@ final class MissionEditViewController: BaseViewController {
                               okTitle: TextLiteral.change,
                               okStyle: .default,
                               okAction: { [weak self] _ in
+            // FIXME: - API 연결 후 작업해야함
             self?.dismiss(animated: true)
         })
     }

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -94,6 +94,20 @@ final class MissionEditViewController: BaseViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
+    private func didChangedTextField(_ text: String) {
+        guard !text.isEmpty else {
+            self.dismiss(animated: true)
+            return
+        }
+        self.makeRequestAlert(title: TextLiteral.missionEditViewControllerChangeMissionAlertTitle,
+                              message: TextLiteral.missionEditViewControllerChangeMissionAlertMessage,
+                              okTitle: TextLiteral.change,
+                              okStyle: .default,
+                              okAction: { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+    }
+    
     // MARK: - selector
     
     @objc
@@ -119,7 +133,8 @@ final class MissionEditViewController: BaseViewController {
 extension MissionEditViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.missionTextField.endEditing(true)
-        self.dismiss(animated: true)
+        guard let text = textField.text else { return true }
+        self.didChangedTextField(text)
         return true
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -43,6 +43,13 @@ final class MissionEditViewController: BaseViewController {
         textField.delegate = self
         return textField
     }()
+    private let missionMaxLengthLabel: UILabel = {
+        let label = UILabel()
+        label.text = "0/18"
+        label.font = .font(.regular, ofSize: 16)
+        label.textColor = .white
+        return label
+    }()
     
     init(mission: String) {
         self.mission = mission
@@ -70,15 +77,22 @@ final class MissionEditViewController: BaseViewController {
     override func setupLayout() {
         self.view.addSubview(self.backgroundView)
         self.backgroundView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(-5)
             $0.height.equalTo(120)
         }
         
-        self.backgroundView.addSubview(missionTextField)
+        self.backgroundView.addSubview(self.missionTextField)
         self.missionTextField.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.center.equalToSuperview()
             $0.height.equalTo(60)
+        }
+        
+        self.backgroundView.addSubview(self.missionMaxLengthLabel)
+        self.missionMaxLengthLabel.snp.makeConstraints {
+            $0.top.equalTo(self.missionTextField.snp.bottom).offset(4)
+            $0.trailing.equalTo(self.missionTextField.snp.trailing)
         }
     }
     
@@ -136,5 +150,20 @@ extension MissionEditViewController: UITextFieldDelegate {
         guard let text = textField.text else { return true }
         self.didChangedTextField(text)
         return true
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        if text.count > 18 {
+            let endIndex = text.index(text.startIndex, offsetBy: 18)
+            let fixedText = text[text.startIndex..<endIndex]
+            textField.text = fixedText + " "
+            
+            DispatchQueue.main.async {
+                self.missionTextField.text = String(fixedText)
+            }
+        }
+        guard text.count <= 18 else { return }
+        self.missionMaxLengthLabel.text = "\(text.count)/18"
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
기획 회의에서 결정된 방장이 미션을 수정할 수 있는 기능을 추가했습니다.
원래는 기존의 코드에서 새 기능만 추가하려 했는데, 너무 복잡해서 View 분리를 살짝 곁들이고 작업을 진행했습니다.
오히려 View 분리한게 리뷰하는데 어려움을 만든 것 같아 죄송스럽네요...
코드에 수정할 부분이 좀 많이 보였는데, 우선은 분리에 초점을 맞췄습니다. (감안하고 봐주세요)
추후에 MVVM으로 리팩토링 하는 과정에서 다듬을 부분 다듬도록 하겠습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. DetailingViewController의 View 분리
2. 미션 수정 버튼(연필 그림) 추가 (터치영역 44x44 설정)
3. 미션 수정 View 추가


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/463-mission-edit-view`브랜치로 오셔서 미션 수정해보시면 됩니다. 
단, 조건이 진행중인 방이고, 방장인 경우만 해당됩니다. 참여자일 경우 해당 버튼이 hidden처리가 잘 되는지 확인해주시면 감사하겠습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/90519320-9343-41ae-9589-20c566bf5e08


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
기존의 코드를 수정하면서 수정해야할 부분이 꽤 보였음에도 불구하고 기존의 형식을 최대한 유지하면서 View를 분리했습니다. 
한 함수에 ui update코드가 다 섞여있는 부분도 그렇고 수정이 매우 필요하지만, 현재 PR에선 미션 수정기능이 핵심이기 때문에 제쳐뒀습니다.
추후에 MVVM으로 수정하는 과정에서 더 다듬으면 좋을 것 같습니다.
그리고 TextField부분을 다른 View의 코드를 긁어왔는데, UIComponent로 만드는 작업이 있으면 좋을 것 같아서 리팩토링 백로그에 적어두었습니다.

허클베리의 API작업이 완료되는 대로 네트워크 코드를 연결하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #463 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
