### PR TITLE
[FEAT] 개별 미션을 수정하는 기능의 네트워크 코드를 추가했습니다.

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		398B1CCA2A13597600DEFCEC /* FSCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = 398B1CC92A13597600DEFCEC /* FSCalendar */; };
 		398B1CCC2A13599D00DEFCEC /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 398B1CCB2A13599D00DEFCEC /* FirebaseAuth */; };
 		399D17AB2856C83B00F50D9D /* DetailEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399D17AA2856C83B00F50D9D /* DetailEditViewController.swift */; };
+		39A938912A48504200EC2CF2 /* MissionEditEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A938902A48504200EC2CF2 /* MissionEditEndPoint.swift */; };
+		39A938932A4852CA00EC2CF2 /* MissionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A938922A4852CA00EC2CF2 /* MissionDTO.swift */; };
+		39A938952A48562500EC2CF2 /* MisstionEditProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A938942A48562500EC2CF2 /* MisstionEditProtocol.swift */; };
+		39A938972A48565500EC2CF2 /* MissionEditAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A938962A48565500EC2CF2 /* MissionEditAPI.swift */; };
 		39C957CE2876E2ED00A04A2B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957CD2876E2ED00A04A2B /* LoginViewController.swift */; };
 		39C957D02879521400A04A2B /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957CF2879521400A04A2B /* String+Extension.swift */; };
 		39C957D22879523200A04A2B /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957D12879523200A04A2B /* Date+Extension.swift */; };
@@ -206,6 +210,10 @@
 		398B1CB92A12415B00DEFCEC /* ManitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		398B1CBB2A12415C00DEFCEC /* ManitoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManitoTests.swift; sourceTree = "<group>"; };
 		399D17AA2856C83B00F50D9D /* DetailEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditViewController.swift; sourceTree = "<group>"; };
+		39A938902A48504200EC2CF2 /* MissionEditEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionEditEndPoint.swift; sourceTree = "<group>"; };
+		39A938922A4852CA00EC2CF2 /* MissionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionDTO.swift; sourceTree = "<group>"; };
+		39A938942A48562500EC2CF2 /* MisstionEditProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MisstionEditProtocol.swift; sourceTree = "<group>"; };
+		39A938962A48565500EC2CF2 /* MissionEditAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionEditAPI.swift; sourceTree = "<group>"; };
 		39C957CD2876E2ED00A04A2B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		39C957CF2879521400A04A2B /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		39C957D12879523200A04A2B /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
@@ -425,6 +433,7 @@
 				39EEF65B28CB3CD600437654 /* LoginAPI.swift */,
 				D739C36428C7B75400161117 /* SettingAPI.swift */,
 				B517C04B28D1FE5F0008BED0 /* TokenAPI.swift */,
+				39A938962A48565500EC2CF2 /* MissionEditAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -441,6 +450,7 @@
 				39EEF65528CB3BB200437654 /* LoginProtocol.swift */,
 				D739C36228C7B69D00161117 /* SettingProtocol.swift */,
 				B517C04D28D1FE660008BED0 /* TokenProtocol.swift */,
+				39A938942A48562500EC2CF2 /* MisstionEditProtocol.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -496,6 +506,7 @@
 				39C95807287DB05C00A04A2B /* SettingEndPoint.swift */,
 				39EEF65D28CB3CFE00437654 /* LoginEndPoint.swift */,
 				B517C04928D1F7EC0008BED0 /* TokenEndPoint.swift */,
+				39A938902A48504200EC2CF2 /* MissionEditEndPoint.swift */,
 			);
 			path = EndPoint;
 			sourceTree = "<group>";
@@ -506,6 +517,7 @@
 				39C957DE2879A35300A04A2B /* RoomDTO.swift */,
 				39E099AC287FC020004F464E /* LetterDTO.swift */,
 				39EEF65F28CB3D6200437654 /* LoginDTO.swift */,
+				39A938922A4852CA00EC2CF2 /* MissionDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1211,6 +1223,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D75E8C7F28D76FFB004A6C41 /* LetterCountBadgeView.swift in Sources */,
+				39A938912A48504200EC2CF2 /* MissionEditEndPoint.swift in Sources */,
 				CBA4D7A62856D48C0018BDC2 /* RoomStateView.swift in Sources */,
 				333BF66628571CF00039F77F /* FriendCollectionViewCell.swift in Sources */,
 				39D95265285B097800183B09 /* CalendarView.swift in Sources */,
@@ -1252,6 +1265,7 @@
 				B54741EA29A494E200B75BA3 /* LetterImageError.swift in Sources */,
 				B5F525422855C97900614FF7 /* UILabel+Extension.swift in Sources */,
 				CB21C33928C4C10200128D25 /* CharacterCollectionViewCell.swift in Sources */,
+				39A938952A48562500EC2CF2 /* MisstionEditProtocol.swift in Sources */,
 				39EEF65A28CB3C7B00437654 /* Token.swift in Sources */,
 				39C95804287DAD3000A04A2B /* LetterEndPoint.swift in Sources */,
 				7E77DB0828BF9D2400E95D4B /* RoomAPI.swift in Sources */,
@@ -1269,6 +1283,7 @@
 				39C95808287DB05C00A04A2B /* SettingEndPoint.swift in Sources */,
 				39C957F4287D9EB400A04A2B /* APIService.swift in Sources */,
 				B5F524CF28519AA000614FF7 /* AppDelegate.swift in Sources */,
+				39A938972A48565500EC2CF2 /* MissionEditAPI.swift in Sources */,
 				435B17682913E71400212663 /* DetailingViewController.swift in Sources */,
 				B5E1F2B2285ECBDF006D880B /* SelectManitteeViewController.swift in Sources */,
 				D7C4A1A92A0B895300C3AE4C /* ChooseCharacterView.swift in Sources */,
@@ -1358,6 +1373,7 @@
 				CB9592B22855C09A00847751 /* ManitoRoomCollectionCell.swift in Sources */,
 				B5AE11F429D32EE700F86FF8 /* SelectManitteeView.swift in Sources */,
 				397A241428BA516B00454E4F /* DetailWaitAPI.swift in Sources */,
+				39A938932A4852CA00EC2CF2 /* MissionDTO.swift in Sources */,
 				B5F525242851A25400614FF7 /* UICollectionView+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Manito/Manito/Global/Literal/URLLiteral.swift
+++ b/Manito/Manito/Global/Literal/URLLiteral.swift
@@ -12,7 +12,7 @@ enum URLLiteral {
     // MARK: - server url
     
     static let developmentUrl: String = "http://43.200.81.247:8080"
-    static let productionUrl: String = "https://dev.aenitto.shop"
+    static let productionUrl: String = "https://ckyeon.store"
     
     // MARK: - notion url
     

--- a/Manito/Manito/Global/Literal/URLLiteral.swift
+++ b/Manito/Manito/Global/Literal/URLLiteral.swift
@@ -12,7 +12,7 @@ enum URLLiteral {
     // MARK: - server url
     
     static let developmentUrl: String = "http://43.200.81.247:8080"
-    static let productionUrl: String = "https://ckyeon.store"
+    static let productionUrl: String = "https://dev.aenitto.shop"
     
     // MARK: - notion url
     

--- a/Manito/Manito/Network/API/MissionEditAPI.swift
+++ b/Manito/Manito/Network/API/MissionEditAPI.swift
@@ -20,4 +20,11 @@ struct MissionEditAPI: MissionEditProtocol {
             .createRequest()
         return try await apiService.request(request)
     }
+    
+    func fetchResetMission(roomId: String) async throws -> MissionDTO? {
+        let request = MissionEditEndPoint
+            .getResetMission(roomId: roomId)
+            .createRequest()
+        return try await apiService.request(request)
+    }
 }

--- a/Manito/Manito/Network/API/MissionEditAPI.swift
+++ b/Manito/Manito/Network/API/MissionEditAPI.swift
@@ -1,0 +1,23 @@
+//
+//  MissionEditAPI.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/25.
+//
+
+import Foundation
+
+struct MissionEditAPI: MissionEditProtocol {
+    private let apiService: Requestable
+    
+    init(apiService: Requestable) {
+        self.apiService = apiService
+    }
+    
+    func patchEditMission(roomId: String, body: MissionDTO) async throws -> String? {
+        let request = MissionEditEndPoint
+            .patchEditMission(roomId: roomId, body: body)
+            .createRequest()
+        return try await apiService.request(request)
+    }
+}

--- a/Manito/Manito/Network/API/MissionEditAPI.swift
+++ b/Manito/Manito/Network/API/MissionEditAPI.swift
@@ -14,7 +14,7 @@ struct MissionEditAPI: MissionEditProtocol {
         self.apiService = apiService
     }
     
-    func patchEditMission(roomId: String, body: MissionDTO) async throws -> String? {
+    func patchEditMission(roomId: String, body: MissionDTO) async throws -> MissionDTO? {
         let request = MissionEditEndPoint
             .patchEditMission(roomId: roomId, body: body)
             .createRequest()

--- a/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
+++ b/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
@@ -12,7 +12,7 @@ enum MissionEditEndPoint: URLRepresentable {
     var path: String {
         switch self {
         case .patchEditMission(let roomId, _):
-            return "/missions/\(roomId)"
+            return "/\(roomId)/individual-mission"
         }
     }
 }

--- a/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
+++ b/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
@@ -9,10 +9,15 @@ import Foundation
 
 enum MissionEditEndPoint: URLRepresentable {
     case patchEditMission(roomId: String, body: MissionDTO)
+    case getResetMission(roomId: String)
+    
     var path: String {
         switch self {
         case .patchEditMission(let roomId, _):
             return "/\(roomId)/individual-mission"
+            
+        case .getResetMission(let roomId):
+            return "/\(roomId)/individual-mission/restore"
         }
     }
 }
@@ -26,6 +31,9 @@ extension MissionEditEndPoint: EndPointable {
         switch self {
         case .patchEditMission:
             return .patch
+            
+        case .getResetMission:
+            return .get
         }
     }
     
@@ -33,6 +41,9 @@ extension MissionEditEndPoint: EndPointable {
         switch self {
         case .patchEditMission(_, let body):
             return body.encode()
+            
+        case .getResetMission:
+            return nil
         }
     }
     
@@ -40,6 +51,9 @@ extension MissionEditEndPoint: EndPointable {
         switch self {
         case .patchEditMission(let roomId, let body):
             return self[.patchEditMission(roomId: roomId, body: body)]
+            
+        case .getResetMission(let roomId):
+            return self[.getResetMission(roomId: roomId)]
         }
     }
     

--- a/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
+++ b/Manito/Manito/Network/EndPoint/MissionEditEndPoint.swift
@@ -1,0 +1,58 @@
+//
+//  MissionEditEndPoint.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/25.
+//
+
+import Foundation
+
+enum MissionEditEndPoint: URLRepresentable {
+    case patchEditMission(roomId: String, body: MissionDTO)
+    var path: String {
+        switch self {
+        case .patchEditMission(let roomId, _):
+            return "/missions/\(roomId)"
+        }
+    }
+}
+
+extension MissionEditEndPoint: EndPointable {
+    var requestTimeOut: Float {
+        return 20
+    }
+    
+    var httpMethod: HTTPMethod {
+        switch self {
+        case .patchEditMission:
+            return .patch
+        }
+    }
+    
+    var requestBody: Data? {
+        switch self {
+        case .patchEditMission(_, let body):
+            return body.encode()
+        }
+    }
+    
+    var url: String {
+        switch self {
+        case .patchEditMission(let roomId, let body):
+            return self[.patchEditMission(roomId: roomId, body: body)]
+        }
+    }
+    
+    func createRequest() -> NetworkRequest {
+        var headers: [String: String] = [:]
+        headers["Content-Type"] = "application/json"
+        headers["authorization"] = "Bearer \(UserDefaultStorage.accessToken)"
+
+        return NetworkRequest(url: self.url,
+                              headers: headers,
+                              reqBody: self.requestBody,
+                              reqTimeout: self.requestTimeOut,
+                              httpMethod: self.httpMethod
+        )
+    }
+}

--- a/Manito/Manito/Network/Models/Request/MissionDTO.swift
+++ b/Manito/Manito/Network/Models/Request/MissionDTO.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct MissionDTO: Encodable {
+struct MissionDTO: Codable {
     let mission: String
 }

--- a/Manito/Manito/Network/Models/Request/MissionDTO.swift
+++ b/Manito/Manito/Network/Models/Request/MissionDTO.swift
@@ -1,0 +1,12 @@
+//
+//  MissionDTO.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/25.
+//
+
+import Foundation
+
+struct MissionDTO: Encodable {
+    let mission: String
+}

--- a/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
+++ b/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  MisstionEditProtocol.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/06/25.
+//
+
+import Foundation
+
+protocol MissionEditProtocol {
+    func patchEditMission(roomId: String, body: MissionDTO) async throws -> String? 
+}

--- a/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
+++ b/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol MissionEditProtocol {
-    func patchEditMission(roomId: String, body: MissionDTO) async throws -> String? 
+    func patchEditMission(roomId: String, body: MissionDTO) async throws -> MissionDTO? 
 }

--- a/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
+++ b/Manito/Manito/Network/Protocol/MisstionEditProtocol.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol MissionEditProtocol {
-    func patchEditMission(roomId: String, body: MissionDTO) async throws -> MissionDTO? 
+    func patchEditMission(roomId: String, body: MissionDTO) async throws -> MissionDTO?
+    func fetchResetMission(roomId: String) async throws -> MissionDTO?
 }

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -91,6 +91,7 @@ final class DetailingViewController: BaseViewController {
         let viewController = MissionEditViewController(mission: mission, roomId: roomId)
         viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .overCurrentContext
+        viewController.setDelegate(self)
         self.present(viewController, animated: true)
     }
     
@@ -263,5 +264,11 @@ extension DetailingViewController: DetailingDelegate {
     
     func didNotShowManitteeView(manitteeName: String) {
         self.openManittee(manitteeName: manitteeName)
+    }
+}
+
+extension DetailingViewController: MissionEditDelegate {
+    func didChangeMission(mission: String) {
+        self.detailingView.updateMission(mission: mission)
     }
 }

--- a/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/DetailingViewController.swift
@@ -87,8 +87,8 @@ final class DetailingViewController: BaseViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    private func presentEditMissionView(mission: String) {
-        let viewController = MissionEditViewController(mission: mission)
+    private func presentEditMissionView(mission: String, roomId: String) {
+        let viewController = MissionEditViewController(mission: mission, roomId: roomId)
         viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .overCurrentContext
         self.present(viewController, animated: true)
@@ -196,7 +196,8 @@ extension DetailingViewController: DetailingDelegate {
     func editMissionButtonDidTap(mission: String) {
         typealias AlertAction = ((UIAlertAction) -> ())
         let editMissionAction: AlertAction = { [weak self] _ in
-            self?.presentEditMissionView(mission: mission)
+            guard let roomId = self?.roomId else { return }
+            self?.presentEditMissionView(mission: mission, roomId: roomId)
         }
         let resetAction: AlertAction = { [weak self] _ in
             self?.resetMission()

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -452,6 +452,10 @@ final class DetailingView: UIView {
         }
     }
     
+    func updateMission(mission: String) {
+        self.missionContentsLabel.text = mission
+    }
+    
     private func setupExitButton(admin: Bool) {
         if admin {
             let menu = UIMenu(options: [], children: [

--- a/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/DetailingView.swift
@@ -366,8 +366,7 @@ final class DetailingView: UIView {
         self.addSubview(self.manittoOpenButtonShadowView)
         self.manittoOpenButtonShadowView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(Size.leadingTrailingPadding)
-            $0.bottom.equalToSuperview().inset(7)
-            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(50)
             $0.height.equalTo(60)
         }
         

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -127,16 +127,17 @@ final class MissionEditViewController: BaseViewController {
                               okTitle: TextLiteral.change,
                               okStyle: .default,
                               okAction: { [weak self] _ in
-            // FIXME: - API 연결 후 작업해야함
-            self?.patchEditMission { result in
+            guard let missionText = self?.missionTextField.text else { return }
+            self?.patchEditMission(mission: missionText) { result in
                 switch result {
                 case .success(let mission):
-                    print(mission)
+                    DispatchQueue.main.async {
+                        self?.dismiss(animated: true)
+                    }
                 case .failure:
                     print("error")
                 }
             }
-            self?.dismiss(animated: true)
         })
     }
     
@@ -163,13 +164,18 @@ final class MissionEditViewController: BaseViewController {
     
     // MARK: - network
     
-    private func patchEditMission(completionHandler: @escaping ((Result<String, NetworkError>) -> Void)) {
-        print("roomId", self.roomId)
-//        Task {
-//            do {
-//                let data = try await self.missionEditService.patchEditMission(roomId: self.roomId, body: MissionDTO(mission: "테스트"))
-//            }
-//        }
+    private func patchEditMission(mission: String, completionHandler: @escaping ((Result<String, NetworkError>) -> Void)) {
+        Task {
+            do {
+                let data = try await self.missionEditService.patchEditMission(roomId: self.roomId,
+                                                                              body: MissionDTO(mission: mission))
+                if let data {
+                    completionHandler(.success(data.mission))
+                } else {
+                    completionHandler(.failure(.unknownError))
+                }
+            }
+        }
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 import SnapKit
 
+protocol MissionEditDelegate: AnyObject {
+    func didChangeMission(mission: String)
+}
+
 final class MissionEditViewController: BaseViewController {
     
     // MARK: - property
@@ -16,6 +20,7 @@ final class MissionEditViewController: BaseViewController {
     let mission: String
     let roomId: String
     private let missionEditService: MissionEditAPI = MissionEditAPI(apiService: APIService())
+    private weak var delegate: MissionEditDelegate?
     
     // MARK: - component
     
@@ -107,6 +112,10 @@ final class MissionEditViewController: BaseViewController {
     
     // MARK: - func
     
+    func setDelegate(_ delegate: DetailingViewController) {
+        self.delegate = delegate
+    }
+    
     private func setupGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissViewController))
         self.view.addGestureRecognizer(tapGesture)
@@ -132,6 +141,7 @@ final class MissionEditViewController: BaseViewController {
                 switch result {
                 case .success(let mission):
                     DispatchQueue.main.async {
+                        self?.delegate?.didChangeMission(mission: mission)
                         self?.dismiss(animated: true)
                     }
                 case .failure:

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -14,6 +14,8 @@ final class MissionEditViewController: BaseViewController {
     // MARK: - property
     
     let mission: String
+    let roomId: String
+    private let missionEditService: MissionEditAPI = MissionEditAPI(apiService: APIService())
     
     // MARK: - component
     
@@ -55,8 +57,9 @@ final class MissionEditViewController: BaseViewController {
     
     // MARK: - init
     
-    init(mission: String) {
+    init(mission: String, roomId: String) {
         self.mission = mission
+        self.roomId = roomId
         super.init()
     }
     
@@ -125,6 +128,14 @@ final class MissionEditViewController: BaseViewController {
                               okStyle: .default,
                               okAction: { [weak self] _ in
             // FIXME: - API 연결 후 작업해야함
+            self?.patchEditMission { result in
+                switch result {
+                case .success(let mission):
+                    print(mission)
+                case .failure:
+                    print("error")
+                }
+            }
             self?.dismiss(animated: true)
         })
     }
@@ -148,6 +159,17 @@ final class MissionEditViewController: BaseViewController {
         UIView.animate(withDuration: 0.2, animations: {
             self.backgroundView.transform = .identity
         })
+    }
+    
+    // MARK: - network
+    
+    private func patchEditMission(completionHandler: @escaping ((Result<String, NetworkError>) -> Void)) {
+        print("roomId", self.roomId)
+//        Task {
+//            do {
+//                let data = try await self.missionEditService.patchEditMission(roomId: self.roomId, body: MissionDTO(mission: "테스트"))
+//            }
+//        }
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Ing/View/MissionEditViewController.swift
@@ -184,6 +184,10 @@ final class MissionEditViewController: BaseViewController {
                 } else {
                     completionHandler(.failure(.unknownError))
                 }
+            } catch NetworkError.serverError {
+                completionHandler(.failure(.serverError))
+            } catch NetworkError.clientError(let message) {
+                completionHandler(.failure(.clientError(message: message)))
             }
         }
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
앞선 #464 PR에 이어서 네트워크 코드를 추가하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 미션 직접 수정 네트워크 코드 추가
- 미션 되돌리기 코드 추가
- 마니또 공개 버튼 위치 수정 (작업중에 발견해서 현재 브랜치에서 살짝 작업했습니다...)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/467-network-edit-mission`브랜치로 오셔서 진행중인 방의 방장일때 수정 하실 수 있습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->


https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/7ade0f63-209b-492a-9e4d-67ceaaec956f


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현 PR에서 마니또 공개 버튼의 위치를 살짝 조정했습니다. 앞선 PR에서 발견하고 수정했어야 했는데, 현 브랜치에서 작업하다 발견해서 살짝 수정했습니다. 

MissionEditDelegate를 만들어서 미션이 수정되었을때의 이벤트를 DetailIngViewController로 전달하는 방식을 사용했습니다..

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #467 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
