### PR TITLE
[BUGFIX] 대기중 방의 초대코드 관련 버그를 해결했습니다.

### DIFF
--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -52,9 +52,14 @@ final class DetailWaitViewController: BaseViewController {
         self.fetchRoomData()
         self.configureDelegation()
         self.configureNavigationController()
+        self.setupNotificationCenter()
     }
     
     // MARK: - func
+    
+    private func setupNotificationCenter() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.didTapEnterButton), name: .createRoomInvitedCode, object: nil)
+    }
     
     private func configureDelegation() {
         self.detailWaitView.configureDelegation(self)
@@ -98,6 +103,27 @@ final class DetailWaitViewController: BaseViewController {
                                 message: TextLiteral.detailWaitViewControllerLoadDataMessage)
             }
         }
+    }
+    
+    // MARK: - selector
+    
+    @objc
+    private func didTapEnterButton() {
+        guard let room = self.roomInformation,
+              let code = room.invitation?.code,
+              let title = room.roomInformation?.title,
+              let capacity = room.roomInformation?.capacity,
+              let startDate = room.roomInformation?.startDate,
+              let endDate = room.roomInformation?.endDate
+        else { return }
+        let viewController = InvitedCodeViewController(roomInfo: RoomDTO(title: title,
+                                                             capacity: capacity,
+                                                             startDate: startDate,
+                                                             endDate: endDate),
+                                                       code: code)
+        viewController.modalPresentationStyle = .overCurrentContext
+        viewController.modalTransitionStyle = .crossDissolve
+        self.present(viewController, animated: true)
     }
     
     // MARK: - network

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailWaitView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailWaitView.swift
@@ -115,6 +115,7 @@ final class DetailWaitView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setupLayout()
+        self.setupCopyButton()
     }
     
     @available(*, unavailable)
@@ -173,7 +174,7 @@ final class DetailWaitView: UIView {
         }
     }
     
-    private func setupCopyButton(_ invitationCode: String) {
+    private func setupCopyButton() {
         let action = UIAction { [weak self] _ in
             self?.delegate?.codeCopyButtonDidTap()
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
View를 분리하던 #444 PR에서 해당 버그를 발생시킨채 머지가 되었습니다.
해당 두 버그를 해결하는 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 초대코드 복사 버튼을 눌러도 안뜨는 버그 해결
2. 방 생성 후 초대 코드 뷰가 안뜨던 버그 해결
(초대코드 뷰란?)
<img width="374" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/fc6603b2-a063-49b1-986f-e0af1335995a">

1번 버그는 단지 `setupCopyButton`함수를 호출하지 않아서 생기는 문제였기에 호출해줌으로써 해결했습니다.
2번 버그는 방 생성 완료시에 Notification으로 알림을 보내는데 제가 View를 분리하면서 Notification을 받는 코드를 삭제했었습니다... 그래서 해당 코드를 다시 추가해서 해결했습니다 ^__________^

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
feature/469-detailwait-invitationcode-fix 브랜치로 오셔서
1. 방을 만들었을 때 초대코드 뷰가 잘 뜨는지,
2. 대기방에서 초대코드 복사 버튼을 눌렀을 때 토스트뷰가 뜨면서 초대코드가 잘 복사되는지
를 확인해주시면 감사하겠습니다 ^___________^

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/2d88e079-7b70-4d67-ac81-01e03f03c11b



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
아무리 꼼꼼하게 확인한다 해도 놓치는 버그가 항상 생기군요... 이걸 미리 캐치할 수 있는 UI테스트를 만들 수 있다면 좋을 것 같네요! 열심히 해보겠습니다.


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #469 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
