### PR TITLE
[CHORE] URL 숨기기 작업을 위한 PR입니다.

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		333BF66A285864CE0039F77F /* MemoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BF669285864CE0039F77F /* MemoryViewController.swift */; };
 		33BDF5622856E03800564211 /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BDF5612856E03800564211 /* FriendListViewController.swift */; };
 		39018F4228C4708A00C78DBA /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39018F4128C4708A00C78DBA /* UIButton+Extension.swift */; };
+		3915D54B2A7516A2002D6C25 /* URLInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3915D54A2A7516A2002D6C25 /* URLInfo.plist */; };
+		3915D54D2A7516E9002D6C25 /* URLInfo+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3915D54C2A7516E9002D6C25 /* URLInfo+Extension.swift */; };
 		391612D829E9231B004AE982 /* DetailWaitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391612D729E9231B004AE982 /* DetailWaitView.swift */; };
 		391B3003286198C200421F1D /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391B3002286198C200421F1D /* Size.swift */; };
 		392EC77E2855C388006918A9 /* SettingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392EC77D2855C388006918A9 /* SettingButton.swift */; };
@@ -205,6 +207,8 @@
 		333BF669285864CE0039F77F /* MemoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewController.swift; sourceTree = "<group>"; };
 		33BDF5612856E03800564211 /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
 		39018F4128C4708A00C78DBA /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
+		3915D54A2A7516A2002D6C25 /* URLInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = URLInfo.plist; sourceTree = "<group>"; };
+		3915D54C2A7516E9002D6C25 /* URLInfo+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLInfo+Extension.swift"; sourceTree = "<group>"; };
 		391612D729E9231B004AE982 /* DetailWaitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWaitView.swift; sourceTree = "<group>"; };
 		391B3002286198C200421F1D /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
 		392EC77D2855C388006918A9 /* SettingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingButton.swift; sourceTree = "<group>"; };
@@ -867,6 +871,7 @@
 				B5B3C1642A427B5800AABD6F /* UIControl+Combine.swift */,
 				B5B3C16E2A42B37000AABD6F /* UIViewController+Combine.swift */,
 				B50CEE902A445EB700CF1C76 /* UIScrollView+Combine.swift */,
+				3915D54C2A7516E9002D6C25 /* URLInfo+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -909,6 +914,7 @@
 				CB7B23A728C4ECA8004A4CF3 /* Character.swift */,
 				7E15F67D28B35B3D00441305 /* TextLiteral.swift */,
 				D777D2C828C7780E008655BD /* URLLiteral.swift */,
+				3915D54A2A7516A2002D6C25 /* URLInfo.plist */,
 			);
 			path = Literal;
 			sourceTree = "<group>";
@@ -1245,6 +1251,7 @@
 				39FFE33628F45E44008442EE /* GoogleService-Info.plist in Resources */,
 				B50B1B3C285AD2B20080992C /* logo.gif in Resources */,
 				7E0C5C382855B73100F698D1 /* Splash.storyboard in Resources */,
+				3915D54B2A7516A2002D6C25 /* URLInfo.plist in Resources */,
 				B5F524DB28519AA100614FF7 /* LaunchScreen.storyboard in Resources */,
 				B5F524D828519AA100614FF7 /* Assets.xcassets in Resources */,
 				B55BCEB628D99F8600AF7E45 /* Settings.bundle in Resources */,
@@ -1393,6 +1400,7 @@
 				D7C4A1AD2A0DD8FA00C3AE4C /* SettingView.swift in Sources */,
 				39C957CE2876E2ED00A04A2B /* LoginViewController.swift in Sources */,
 				D7C4A1B02A0E522800C3AE4C /* SettingViewController+MailComposeViewControllerDelegate.swift in Sources */,
+				3915D54D2A7516E9002D6C25 /* URLInfo+Extension.swift in Sources */,
 				33BDF5622856E03800564211 /* FriendListViewController.swift in Sources */,
 				B5F5250E2851A07700614FF7 /* LetterViewController.swift in Sources */,
 				B5F5251C2851A19A00614FF7 /* BaseCollectionViewCell.swift in Sources */,

--- a/Manito/Manito/Global/Extension/URLInfo+Extension.swift
+++ b/Manito/Manito/Global/Extension/URLInfo+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  URLInfo+Extension.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 2023/07/29.
+//
+
+import Foundation
+
+extension Bundle {
+    var productionURL: String {
+        guard let file = self.path(forResource: "URLInfo", ofType: "plist") else { return "URLInfo 파일이 없습니다." }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["Production URL"] as? String else { fatalError("Production URL을 입력해 주세요") }
+        return key
+    }
+    
+    var developmentURL: String {
+        guard let file = self.path(forResource: "URLInfo", ofType: "plist") else { return "URLInfo 파일이 없습니다." }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["Development URL"] as? String else { fatalError("Development URL을 입력해 주세요") }
+        return key
+    }
+}

--- a/Manito/Manito/Global/Literal/URLInfo.plist
+++ b/Manito/Manito/Global/Literal/URLInfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Development URL</key>
+	<string>Development URL을 입력해주세요.</string>
+	<key>Production URL</key>
+	<string>Production URL을 입력해주세요.</string>
+</dict>
+</plist>

--- a/Manito/Manito/Global/Literal/URLLiteral.swift
+++ b/Manito/Manito/Global/Literal/URLLiteral.swift
@@ -11,8 +11,8 @@ enum URLLiteral {
     
     // MARK: - server url
     
-    static let developmentUrl: String = "http://43.200.81.247:8080"
-    static let productionUrl: String = "https://dev.aenitto.shop"
+    static let developmentUrl: String = Bundle.main.developmentURL
+    static let productionUrl: String = Bundle.main.productionURL
     
     // MARK: - notion url
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
회원탈퇴 기능을 추가하기 이전에 해당 작업이 선행되었어야 했습니다. 
그 이유는 현재 Production 서버로만 모든 걸 사용하고 있는데, 허클베리가 개발서버와 배포서버를 나눠주셨고 회원탈퇴 기능은 개발서버에만 우선적으로 배포되어있기 때문입니다.

URL을 숨겨야하는 이유는 무엇인가?? 에 대한 답변을 드리자면, 누군가 악의적인 마음을 가지고 공격을 한다고 했을때 전혀 대비가 되어있지 않기 때문입니다. 애초에 처음 올릴 때 부터 해당 값을 숨기고 사용했어야 했는데.. 늦게나마 해당 값을 숨기고자 합니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
URLInfo.plist 파일을 만들었습니다.
해당 파일에 URL 값을 개인적으로 추가해서 사용하시면 됩니다.
### 그럼 매번 커밋할 때마다 해당 값을 지워야 하는가??? 

아닙니다. 터미널에
`git update-index --skip-worktree Manito/Manito/Global/Literal/URLInfo.plist`
해당 코드를 입력하면 더이상 git이 추적을 하지 않게 됩니다.

### 🚨 꼭! 먼저 세팅하고 이후 작업을 진행해 주세요. 한번이라도 커밋에 올라오면 흔적이 남기 때문에 초기 작업이 중요합니다!

**설정 전**
<img width="567" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/5de15fa8-a445-4167-aadd-936bd367e56c">

**설정 후**
<img width="1113" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/1406669a-0bc7-4607-89c2-cdbfd4fed932">

URLInfo.plist의 값을 사용하는 URL주소로 수정했음에도 git이 추적하지 않는 모습입니다. 


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/477-hide-url` 브랜치로 오셔서 
![image](https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/9aff6246-0df9-40dc-87e1-0843994bb201)

위처럼 수정하시고 테스트 부탁드립니다. 현재 저희는 Production URL로 모든것이 연결되어 있습니다.
URL 주소는 저희 노션에 `기밀사항` 페이지에 있습니다.

잘 모르겠다면 언제든 연락주십셔 ^________^

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

Q. gitignore를 사용하면 더 편하게 숨길 수 있지 않나요??

A. 네 맞습니다. 애초에 gitignore를 추가하고 모두가 같은 세팅으로 진행했다면 문제없이 숨길 수 있었을겁니다. 하지만 이미 프로젝트는 진행되었고 뒤늦게 숨겨야하는 상황이 생겼습니다. 그리고 gitignore는 애초에 흔적조차 생기지 않기 때문에 어디에 값을 추가해야하는지 모르는 경우가 생길 수 있습니다. 그래서 현 PR처럼 껍데기를 만들어두고 해당 plist에 입력하면 되는 구조로 만들었습니다.


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #477 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://nareunhagae.tistory.com/44