### PR TITLE
[FIX] LetterViewController 부분에서 발생하는 메모리 릭 문제를 해결했습니다.

### DIFF
--- a/Manito/Manito/Screens/Letter/Views/UIComponents/LetterHeaderView.swift
+++ b/Manito/Manito/Screens/Letter/Views/UIComponents/LetterHeaderView.swift
@@ -33,8 +33,7 @@ final class LetterHeaderView: UICollectionReusableView {
 
     var segmentedControlTapPublisher: AnyPublisher<Int, Never> {
         return self.segmentedControl.tapPublisher
-            .map { [weak self] in self?.segmentedControl.selectedSegmentIndex }
-            .map { $0! }
+            .compactMap { [weak self] in self?.segmentedControl.selectedSegmentIndex }
             .eraseToAnyPublisher()
     }
     

--- a/Manito/Manito/Screens/Letter/Views/Views/LetterView.swift
+++ b/Manito/Manito/Screens/Letter/Views/Views/LetterView.swift
@@ -182,7 +182,7 @@ extension LetterView {
 // MARK: - UICollectionViewLayout
 extension LetterView {
     private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { index, environment -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] index, environment -> NSCollectionLayoutSection? in
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
                 heightDimension: .estimated(500)
@@ -197,7 +197,7 @@ extension LetterView {
 
             let section = NSCollectionLayoutSection(group: group)
             section.contentInsets = ConstantSize.sectionContentInset
-            section.boundarySupplementaryItems = self.sectionHeader()
+            section.boundarySupplementaryItems = self?.sectionHeader() ?? []
             section.interGroupSpacing = ConstantSize.groupInterItemSpacing
 
             return section


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
LetterViewController에서 LetterView와 LetterHeaderView가 메모리에서 해제되지 않는 문제가 발생했습니다.
<img width="710" alt="스크린샷 2023-08-22 오후 4 10 38" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/74eea90b-fa8c-4f9d-bf7b-0420335bfdb2">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
LetterView와 LetterHeaderView만 계속 메모리에서 해제되지 않아서 HeaderView에 문제가 있다고 판단하여 HeaderView관련 코드를 주석처리하고 빌드를 해보니깐 LetterView가 제대로 메모리 해제되는걸 확인했습니다.
<img width="708" alt="스크린샷 2023-08-22 오후 4 17 21" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/28331e3b-7d39-4fdc-a697-9f54f3e56a4f">

`[weak self]` 누락된 부분을 열심히 찾아본 결과, `LetterView`안에 있는 `createLayout` 메서드에서 `[weak self]` 누락을 확인했고, 해당 부분이 Header를 설정하는 `sectionHeader` 메서드에 self를 써주는 부분이라서 문제가 생긴 거 같습니다.

`[weak self]`를 써주고 나니 메모리 해제가 잘 되는걸 확인할 수 있습니다.
<img width="708" alt="스크린샷 2023-08-22 오후 4 28 23" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/2796b378-ff48-4367-9697-2eb7fc8961a2">

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

메모리 릭 관련 테스트를 해보고 싶으시면 빌드 런하는 아이콘을 꾹 누르면 Profile로 변경할 수 있습니다.
<img width="388" alt="스크린샷 2023-08-22 오후 4 35 57" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/9ccd54c4-8b49-40a0-9663-ce3ae41c4e4a">

Profile로 빌드하시면 Instrument가 뜨는데, 거기서 `Leaks`를 선택하시고, Leaks 화면에서 녹화 버튼을 누르면 Memory Leak이 발생하는지 확인하실 수 있습니다.

표에 있는 `Persistent(#)`는 메모리에 계속 남아있는 클래스의 갯수이고, `Transient`는 해제된 클래스의 갯수입니다. 따라서, `Persistent`가 1를 초과하면 안됩니다. 그런 식으로 봐주시면 됩니다.🙇‍♂️


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
CreateLetterView에서 현재 쪽지가 안보내지는 문제가 있습니다.
~417 에러 코드가 뜨는데 이유를 모르겠네요..🥲 얼른 해결해보겠습니다.🙇‍♂️~
허클베리와 해결 완료...🙇‍♂️


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #486


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- https://velog.io/@mytrace/Xcode-Instruments-2-%ED%99%9C%EC%9A%A9%EC%98%88%EC%8B%9C
