### PR TITLE
[CHORE] 방 참여시 캐릭터 인덱스가 설정 안되는 문제를 수정했습니다.

### DIFF
--- a/Manito/Manito/Screens/ChooseCharacter/View/ChooseCharacterView.swift
+++ b/Manito/Manito/Screens/ChooseCharacter/View/ChooseCharacterView.swift
@@ -110,7 +110,7 @@ final class ChooseCharacterView: UIView, BaseViewType {
             self?.delegate?.closeButtonDidTap()
         }
         let didTapJoinButton = UIAction { [weak self] _ in
-            self?.delegate?.joinButtonDidTap(characterIndex: self?.manittoCollectionView.characterIndex ?? 0)
+            self?.delegate?.joinButtonDidTap(characterIndex: self?.manittoCollectionView.characterIndexTapPublisher.value ?? 0)
         }
         
         self.backButton.addAction(didTapBackButton, for: .touchUpInside)

--- a/Manito/Manito/Screens/CreateRoom/UIComponent/CharacterCollectionView.swift
+++ b/Manito/Manito/Screens/CreateRoom/UIComponent/CharacterCollectionView.swift
@@ -45,9 +45,8 @@ final class CharacterCollectionView: UIView {
     }()
     
     // MARK: - property
-    // FIXME: characterIndex 삭제예정
-    private(set) var characterIndex: Int = 0
-    let characterIndexTapPublisher = PassthroughSubject<Int, Never>()
+    
+    let characterIndexTapPublisher = CurrentValueSubject<Int, Never>(0)
     
     // MARK: - init
     


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

방 생성시에는 문제가 없는데, 방 참여할 때 캐릭터의 인덱스가 항상 0번으로 고정되는 문제가 있었습니다.

<img width="376" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/0cfb39c4-2097-4451-a638-58e6afe6af06">


위 사진은 호야가 배포 서버에 만들어준 방입니다.

<img width="372" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/d1e6ef85-5562-47db-96a2-4220ccb0e7f7">

6번째 캐릭터(인덱스 5번)을 선택하고 들어가도

<img width="298" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/1236c455-d938-43af-858b-64c62b55bd39">

0번으로 선택되어있는 문제가 있었습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

문제는 삭제예정이라 적어주셨던 `characterIndex = 0`의 값을 사용하고 있었기 때문입니다. 바로 아래 해당값을 스트림으로 변경해주셨지만 해당 변수를 삭제하지 않고 그대로 사용중이었습니다.

1. 문제의 `characterIndex`값을 삭제했습니다
2. `PassthroughSubject`로 만들었던 스트림을 `CurrentValueSubject`로 변경함으로써 초기값을 설정할 수 있었고, 사용하는 부분에서 .value를 통해 Int값에 접근할 수 있었습니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
해당 브랜치로 오셔서 방 참가를 해보시면 됩니다.
배포 서버 초대코드는 `KTBQ2B` 입니다. 방 id는 268번 입니다. 포스트맨에 `rooms/268/participants` API로 조회해보시면 됩니다!
개발 서버 초대코드는 `20QBFT` 입니다. 방 id는 340번 입니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

<img width="449" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/88be8be0-9f60-4bb4-9fac-45f2060e6a3d">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
각각의 스트림으로 분리되어 있어서 그런지 굉장히 조금만 수정해도 문제가 해결되네요!
아주 좋아요 ^__________^

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #525


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
