### PR TITLE
[CHORE] ColorSet의 yellow네이밍을 수정합니다.

### DIFF
--- a/Manito/Manito/Screens/Main/Cell/CreateRoomCollectionViewCell.swift
+++ b/Manito/Manito/Screens/Main/Cell/CreateRoomCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class CreateRoomCollectionViewCell: UICollectionViewCell, BaseViewType {
     private let imageView: UIImageView = UIImageView(image: UIImage.Icon.newRoom)    
     private let circleView: UIView = {
         let circleView = UIView()
-        circleView.backgroundColor = .yellow
+        circleView.backgroundColor = .yellow001
         circleView.layer.cornerRadius = 44
         circleView.layer.borderWidth = 1
         circleView.layer.borderColor = UIColor.grey003.cgColor

--- a/Manito/Manito/Screens/ParticipateRoom/View/ParticipationRoomDetailsView.swift
+++ b/Manito/Manito/Screens/ParticipateRoom/View/ParticipationRoomDetailsView.swift
@@ -48,7 +48,7 @@ final class ParticipationRoomDetailsView: UIView, BaseViewType {
         button.setTitle(TextLiteral.participationRoomDetailsViewControllerNoButtonLabel, for: .normal)
         button.setTitleColor(.black, for: .normal)
         button.titleLabel?.font = .font(.regular, ofSize: 35)
-        button.backgroundColor = .yellow
+        button.backgroundColor = .yellow001
         button.makeShadow(color: .shadowYellow, opacity: 1.0, offset: CGSize(width: 0, height: 4), radius: 1)
         button.layer.cornerRadius = 22
         return button
@@ -58,7 +58,7 @@ final class ParticipationRoomDetailsView: UIView, BaseViewType {
         button.setTitle(TextLiteral.participationRoomDetailsViewControllerYesBUttonLabel, for: .normal)
         button.setTitleColor(.black, for: .normal)
         button.titleLabel?.font = .font(.regular, ofSize: 35)
-        button.backgroundColor = .yellow
+        button.backgroundColor = .yellow001
         button.makeShadow(color: .shadowYellow, opacity: 1.0, offset: CGSize(width: 0, height: 4), radius: 1)
         button.layer.cornerRadius = 22
         return button

--- a/Manito/Modules/MTResource/MTResource/ColorSet.swift
+++ b/Manito/Modules/MTResource/MTResource/ColorSet.swift
@@ -47,7 +47,7 @@ public extension UIColor {
 
     // MARK: - yellow
 
-    static var yellow: UIColor { return UIColor(hex: "#EDC845") }
+    static var yellow001: UIColor { return UIColor(hex: "#EDC845") }
     static var shadowYellow: UIColor { return UIColor(hex: "#C7A83C") }
 
     // MARK: - pink


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

프레임워크로 분리한 ColorSet의 노란색이 적용되지 않는 문제가 있었습니다.

<img width="321" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/f26da3cb-9059-41fe-8748-2579fc293812">


<img width="308" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/37d77574-f874-460d-9f20-0591f9b16229">

기존 사용하던 UIColor+Extension에 yellow가 있었는데 해당 Extension이 프레임워크 위치로 옮겨지면서 해당 문제가 발생한 것 같습니다.
UIColor.yellow라고 사용했을때 우선순위가 저희가 프레임워크로 분리한 yellow보단 내장되어있는 yellow의 우선순위가 더 높았던 것 같습니다.
해당 문제를 해결하기 위한 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
yellow라고 네이밍 되어있던걸 yellow001로 수정했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

현재 브랜치로 오셔서
1. 메인 화면에서 방 생성하기 아이콘 배경색이 제대로 들어갔는지 확인
2. 방 참가하기 했을 때 YES NO 버튼 색이 제대로 들어갔는지 확인
부탁드립니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->
<img width="321" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/6af589a2-bfcf-49f4-a3a2-96b687246e20">

<img width="326" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/fd56794b-bfc2-407a-8d6e-96472cb9905b">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
프레임워크로 분리했을때의 우선순위 변경이 생기는게 신기하고 재밌네요! ^___________^


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #537


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
