### PR TITLE
[FIX] 인스타그램 공유가 안되는 문제를 해결했습니다.

### DIFF
--- a/Manito/Manito/Data/Network/Foundation/Key+Extension.swift
+++ b/Manito/Manito/Data/Network/Foundation/Key+Extension.swift
@@ -21,4 +21,11 @@ extension Bundle {
         guard let key = resource["Development URL"] as? String else { fatalError("Development URL을 입력해 주세요") }
         return key
     }
+    
+    var instagramAppID: String {
+        guard let file = self.path(forResource: "Key", ofType: "plist") else { return "Key 파일이 없습니다." }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["instagramAppID"] as? String else { fatalError("instagramAppID를 입력해 주세요") }
+        return key
+    }
 }

--- a/Manito/Manito/Util/Literal/URLLiteral.swift
+++ b/Manito/Manito/Util/Literal/URLLiteral.swift
@@ -14,7 +14,7 @@ enum URLLiteral {
     }
     
     enum Memory {
-        static let instagram: String = "instagram-stories://share"
+        static let instagram: String = "instagram-stories://share?source_application=\(Bundle.main.instagramAppID)"
         static let instagramBundle: String = "com.instagram.sharedSticker.stickerImage"
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
MemoryVC에서 인스타그램 공유가 안되는 문제가 발견되어 해당 문제를 해결했습니다.

<img src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/a4721431-7640-43ec-9018-12d3910a4928" width="400">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

자세한 작업 내용은 블로그에 적어뒀습니다. 궁금하신 분들은 하단 링크로 들어가서 보시면 됩니다.
- https://yoonah-dev.oopy.io/eb077683-4278-411c-85a3-bc339f14232f

인스타그램 공유가 안되는 문제는 **2023년 1월부터 바뀐 Meta 정책에 의해서 Meta Developer에서 앱 ID를 부여받은 앱에 한해서만 인스타 공유가 가능**해졌기 때문입니다.

따라서, Meta Developer 페이지에 애니또 앱을 생성하고 앱 ID를 받았습니다.

![스크린샷 2023-10-18 오후 10 10 30](https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/4d9ec5c7-98d5-4a1f-8202-2fd679b5c7f8)

실제로 수정된 코드는 인스타그램 스토리 관련 부분 코드밖에 없어서 PR을 보기에 어려움은 없으실 겁니다.
```swift
static let instagram: String = "instagram-stories://share?source_application=\(Bundle.main.instagramAppID)"
```

앱 수준 사용 제한이 걸려있긴 한데, 저희는 스토리 공유 용도로만 사용하기 때문에 큰 문제는 없을 것으로 보입니다.

![스크린샷 2023-10-19 오전 11 35 32](https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/f4a88a02-5cbe-46e7-85d9-c2b0665c5f90)

애니또 대시보드에서 딱히 할 수 있는건 없긴 한데, 참여하고 싶으신 분들은 FacebookID나 사용자 이름 말씀해주시면 대시보드에 개발자 역할로 추가해드리겠습니다. 말씀해주세요.🙇‍♂️

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->

함께 했던 기록 부분에서 테스트해주시면 됩니다.
그 전에 꼭 Key.plist에 instagramAppID를 설정해주세요. AppID는 노션 기밀사항 내부에 적어뒀습니다.


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/55099365/163d871d-62df-4e92-9fc4-5ce3863d2172

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- resolve #567 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- https://developers.facebook.com/docs/instagram/sharing-to-stories#------------2
