### PR TITLE
[BUGFIX] ChooseCharacterViewController 가 메모리 릭이 일어나는 부분을 수정했습니다. 

### DIFF
--- a/Manito/Manito/Presentation/Scene/ParticipateRoomScene/ViewController/ChooseCharacterViewController.swift
+++ b/Manito/Manito/Presentation/Scene/ParticipateRoomScene/ViewController/ChooseCharacterViewController.swift
@@ -87,14 +87,14 @@ final class ChooseCharacterViewController: UIViewController, Navigationable {
     
     private func bindUI() {
         self.chooseCharacterView.backButtonTapPublisher
-            .sink {
-                self.navigationController?.popViewController(animated: true)
+            .sink { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &self.cancellable)
         
         self.chooseCharacterView.closeButtonTapPublisher
-            .sink {
-                self.dismiss(animated: true)
+            .sink { [weak self] _ in
+                self?.dismiss(animated: true)
             }
             .store(in: &self.cancellable)
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
처음에는 방참가 부분에서 케릭터 선택 컬랙션 뷰에서 메모리 릭이 일어나는 줄 알았는데 
어제 듀나랑 얘기하면서 컬랙션 뷰가 아닌 뷰 컨트롤러일 수 도 있겠다 라는 말을 듣고 확인해보니
케릭터 선택 뷰가 있는 ChooseCharacterViewController 에서 메모리 릭이 일어나고 있었습니다. 

문제는 sink 부분에 [weak self] 를 하지 않아서 strong 참조가 되고 있어서 생겼습니다. 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- [weak self] 추가

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/581-character-memoryleak-bugfix` 에 오셔서 방참여 후 `IWGE0P` 코드로 진입하여 메모리 릭을 확인해보시면 됩니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| 원래 | 수정 후 |
| ----| --------|
|<img src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/59243274/1e1caef4-0845-4065-afb8-76c3e649b191" width="350">         | <img src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/59243274/ec5fc7c5-8fe4-44fa-b9e0-03bc27d35fa6" width="350">            |




원래는 ChooseCharacterViewController 도 계속 쌓이고 manittoCollectionView 도 계속 쌓였으나 이젠 잘 해제 됩니다. 

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
weak self 확인을 잘하자..! 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #581 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
