### PR TITLE
[REFACTOR] 방 정보 수정 View를 CleanArchitecture + MVVM 구조로 리팩토링 했습니다.

### DIFF
--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		39632A732AF0DC2E00A6E61D /* DetailEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */; };
 		39632A762AF0EE6600A6E61D /* DetailEditUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */; };
 		39632A842AFB24FD00A6E61D /* DetailEditUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A832AFB24FD00A6E61D /* DetailEditUsecaseTest.swift */; };
+		39632AC52B0B477700A6E61D /* DetailEditUsecaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632AC42B0B477700A6E61D /* DetailEditUsecaseError.swift */; };
 		397A241028BA494100454E4F /* APIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957F0287D984900A04A2B /* APIEnvironment.swift */; };
 		39833CFE2AB09A6C009D173A /* Keyboardable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39833CFD2AB09A6C009D173A /* Keyboardable.swift */; };
 		398B1C9B29F10B0300DEFCEC /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */; };
@@ -293,6 +294,7 @@
 		39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditViewModel.swift; sourceTree = "<group>"; };
 		39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecase.swift; sourceTree = "<group>"; };
 		39632A832AFB24FD00A6E61D /* DetailEditUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecaseTest.swift; sourceTree = "<group>"; };
+		39632AC42B0B477700A6E61D /* DetailEditUsecaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecaseError.swift; sourceTree = "<group>"; };
 		39833CFD2AB09A6C009D173A /* Keyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyboardable.swift; sourceTree = "<group>"; };
 		398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
 		398B1CB92A12415B00DEFCEC /* ManitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -636,6 +638,14 @@
 				39632A2A2AD842A800A6E61D /* DetailWaitUsecaseError.swift */,
 			);
 			path = DetailWait;
+			sourceTree = "<group>";
+		};
+		39632AC32B0B476100A6E61D /* DetailEdit */ = {
+			isa = PBXGroup;
+			children = (
+				39632AC42B0B477700A6E61D /* DetailEditUsecaseError.swift */,
+			);
+			path = DetailEdit;
 			sourceTree = "<group>";
 		};
 		398B1CBA2A12415C00DEFCEC /* ManitoTests */ = {
@@ -989,6 +999,7 @@
 		B55469FD2AADB903004D9FE6 /* Error */ = {
 			isa = PBXGroup;
 			children = (
+				39632AC32B0B476100A6E61D /* DetailEdit */,
 				39632A292AD8429000A6E61D /* DetailWait */,
 				B5422CD42ADD42C00051A966 /* DetailScene */,
 				B5546A092AADCAFD004D9FE6 /* LetterScene */,
@@ -2056,6 +2067,7 @@
 				39C957D22879523200A04A2B /* Date+Extension.swift in Sources */,
 				B5422CD62ADD42CD0051A966 /* DetailUsecaseError.swift in Sources */,
 				B55469B62AA96F54004D9FE6 /* DefaultCharacterType.swift in Sources */,
+				39632AC52B0B477700A6E61D /* DetailEditUsecaseError.swift in Sources */,
 				B53A35C82A96F84700B720BC /* LetterRepositoryImpl.swift in Sources */,
 				39EE956F2A404A3800AF6857 /* MissionEditViewController.swift in Sources */,
 				B5F5250A2851A06700614FF7 /* DetailWaitViewController.swift in Sources */,

--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		39632A2B2AD842A800A6E61D /* DetailWaitUsecaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A2A2AD842A800A6E61D /* DetailWaitUsecaseError.swift */; };
 		39632A732AF0DC2E00A6E61D /* DetailEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */; };
 		39632A762AF0EE6600A6E61D /* DetailEditUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */; };
+		39632A842AFB24FD00A6E61D /* DetailEditUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A832AFB24FD00A6E61D /* DetailEditUsecaseTest.swift */; };
 		397A241028BA494100454E4F /* APIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957F0287D984900A04A2B /* APIEnvironment.swift */; };
 		39833CFE2AB09A6C009D173A /* Keyboardable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39833CFD2AB09A6C009D173A /* Keyboardable.swift */; };
 		398B1C9B29F10B0300DEFCEC /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */; };
@@ -276,6 +277,7 @@
 		39632A2A2AD842A800A6E61D /* DetailWaitUsecaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWaitUsecaseError.swift; sourceTree = "<group>"; };
 		39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditViewModel.swift; sourceTree = "<group>"; };
 		39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecase.swift; sourceTree = "<group>"; };
+		39632A832AFB24FD00A6E61D /* DetailEditUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecaseTest.swift; sourceTree = "<group>"; };
 		39833CFD2AB09A6C009D173A /* Keyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyboardable.swift; sourceTree = "<group>"; };
 		398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
 		398B1CB92A12415B00DEFCEC /* ManitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -593,6 +595,7 @@
 			isa = PBXGroup;
 			children = (
 				39632A272AD81F2E00A6E61D /* DetailWaitUsecaseTest.swift */,
+				39632A832AFB24FD00A6E61D /* DetailEditUsecaseTest.swift */,
 			);
 			path = Usecase;
 			sourceTree = "<group>";
@@ -1895,6 +1898,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39632A842AFB24FD00A6E61D /* DetailEditUsecaseTest.swift in Sources */,
 				390E5CAD2AB89BCE00EBE52E /* RoomListItemTest.swift in Sources */,
 				390E5CB22AB8A70600EBE52E /* Date+ExtensionTest.swift in Sources */,
 				398CED082AB9E48F00F50CBD /* RoomInfoTest.swift in Sources */,

--- a/Manito/Manito.xcodeproj/project.pbxproj
+++ b/Manito/Manito.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		395B5BCC2A2F6A9700CE1420 /* DetailWaitViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395B5BCB2A2F6A9700CE1420 /* DetailWaitViewModelTest.swift */; };
 		39632A282AD81F2E00A6E61D /* DetailWaitUsecaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A272AD81F2E00A6E61D /* DetailWaitUsecaseTest.swift */; };
 		39632A2B2AD842A800A6E61D /* DetailWaitUsecaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A2A2AD842A800A6E61D /* DetailWaitUsecaseError.swift */; };
+		39632A732AF0DC2E00A6E61D /* DetailEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */; };
+		39632A762AF0EE6600A6E61D /* DetailEditUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */; };
 		397A241028BA494100454E4F /* APIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C957F0287D984900A04A2B /* APIEnvironment.swift */; };
 		39833CFE2AB09A6C009D173A /* Keyboardable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39833CFD2AB09A6C009D173A /* Keyboardable.swift */; };
 		398B1C9B29F10B0300DEFCEC /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */; };
@@ -272,6 +274,8 @@
 		395B5BCB2A2F6A9700CE1420 /* DetailWaitViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWaitViewModelTest.swift; sourceTree = "<group>"; };
 		39632A272AD81F2E00A6E61D /* DetailWaitUsecaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWaitUsecaseTest.swift; sourceTree = "<group>"; };
 		39632A2A2AD842A800A6E61D /* DetailWaitUsecaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWaitUsecaseError.swift; sourceTree = "<group>"; };
+		39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditViewModel.swift; sourceTree = "<group>"; };
+		39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditUsecase.swift; sourceTree = "<group>"; };
 		39833CFD2AB09A6C009D173A /* Keyboardable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyboardable.swift; sourceTree = "<group>"; };
 		398B1C9A29F10B0300DEFCEC /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
 		398B1CB92A12415B00DEFCEC /* ManitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -580,6 +584,7 @@
 			isa = PBXGroup;
 			children = (
 				395B5BC12A25E20000CE1420 /* DetailWaitViewModel.swift */,
+				39632A722AF0DC2E00A6E61D /* DetailEditViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -662,6 +667,7 @@
 			isa = PBXGroup;
 			children = (
 				39EF30F82AD3DE6700466A90 /* DetailWaitUseCase.swift */,
+				39632A752AF0EE6600A6E61D /* DetailEditUsecase.swift */,
 			);
 			path = DetailWait;
 			sourceTree = "<group>";
@@ -1917,6 +1923,7 @@
 				B5422CCF2ADD3DEC0051A966 /* MemoryUsecase.swift in Sources */,
 				B577E5002AC373CA003CC102 /* PhotoPickerManager.swift in Sources */,
 				B5A085E62A972EB700C8A98D /* LetterDTO.swift in Sources */,
+				39632A732AF0DC2E00A6E61D /* DetailEditViewModel.swift in Sources */,
 				7E3058C82854B64D00489E6A /* InputCapacityView.swift in Sources */,
 				B53A35C62A96F6DB00B720BC /* RoomParticipationRepository.swift in Sources */,
 				CBA15C94285CE1A80051EDE2 /* ChooseCharacterViewController.swift in Sources */,
@@ -2012,6 +2019,7 @@
 				B57D57692AD97DAE00626BCD /* SplashView.swift in Sources */,
 				D75DEEC72AA612DB00BD3AC7 /* ParticipateRoomViewModel.swift in Sources */,
 				B5F525262851A26D00614FF7 /* NSObject+ClassName.swift in Sources */,
+				39632A762AF0EE6600A6E61D /* DetailEditUsecase.swift in Sources */,
 				3904F4FA2AA36F4F00B6264F /* UserInfo.swift in Sources */,
 				39FFE32828EEFFFE008442EE /* MoreButton.swift in Sources */,
 				7E0C5C362855B22700F698D1 /* CreateNicknameViewController.swift in Sources */,

--- a/Manito/Manito/Domain/Error/DetailEdit/DetailEditUsecaseError.swift
+++ b/Manito/Manito/Domain/Error/DetailEdit/DetailEditUsecaseError.swift
@@ -1,0 +1,20 @@
+//
+//  DetailEditUsecaseError.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 11/20/23.
+//
+
+import Foundation
+
+enum DetailEditUsecaseError: LocalizedError {
+    case failedToChangeRoomInfo
+}
+
+extension DetailEditUsecaseError {
+    var errorDescription: String? {
+        switch self {
+        case .failedToChangeRoomInfo: return TextLiteral.DetailEdit.Error.message.localized()
+        }
+    }
+}

--- a/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
+++ b/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
@@ -6,3 +6,27 @@
 //
 
 import Foundation
+
+protocol DetailEditUsecase {
+    var roomInformation: RoomInfo { get set }
+    
+    func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int
+}
+
+final class DetailEditUsecaseImpl: DetailEditUsecase {
+    
+    @Published var roomInformation: RoomInfo
+    
+    let repository: DetailRoomRepository
+    
+    init(roomInformation: RoomInfo, repository: DetailRoomRepository) {
+        self.roomInformation = roomInformation
+        self.repository = repository
+    }
+    
+    func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {
+        let statusCode = try await self.repository.putRoomInfo(roomId: self.roomInformation.roomInformation.id.description,
+                                                               roomInfo: roomDto)
+        return statusCode
+    }
+}

--- a/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
+++ b/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
@@ -10,8 +10,8 @@ import Foundation
 protocol DetailEditUsecase {
     var roomInformation: RoomInfo { get set }
     
-    func validStartDatePast(startDate: String) -> Bool
-    func validMemberCountOver(capacity: Int) -> Bool
+    func vaildStartDateIsNotPast(startDate: String) -> Bool
+    func vaildMemberCountIsUnder(capacity: Int) -> Bool
     func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int
 }
 
@@ -25,15 +25,15 @@ final class DetailEditUsecaseImpl: DetailEditUsecase {
         self.repository = repository
     }
     
-    func validStartDatePast(startDate: String) -> Bool {
+    func vaildStartDateIsNotPast(startDate: String) -> Bool {
         guard let startDate = startDate.toDefaultDate else { return false }
         let isPast = startDate.isPast
         return !isPast
     }
     
-    func validMemberCountOver(capacity: Int) -> Bool {
-        let isUnderOverMember = self.roomInformation.participants.count <= capacity
-        return isUnderOverMember
+    func vaildMemberCountIsUnder(capacity: Int) -> Bool {
+        let isUnderMember = self.roomInformation.participants.count <= capacity
+        return isUnderMember
     }
     
     func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {

--- a/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
+++ b/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
@@ -37,8 +37,12 @@ final class DetailEditUsecaseImpl: DetailEditUsecase {
     }
     
     func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {
-        let statusCode = try await self.repository.putRoomInfo(roomId: self.roomInformation.roomInformation.id.description,
-                                                               roomInfo: roomDto)
-        return statusCode
+        do {
+            let statusCode = try await self.repository.putRoomInfo(roomId: self.roomInformation.roomInformation.id.description,
+                                                                   roomInfo: roomDto)
+            return statusCode
+        } catch {
+            throw DetailEditUsecaseError.failedToChangeRoomInfo
+        }
     }
 }

--- a/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
+++ b/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
@@ -1,0 +1,8 @@
+//
+//  DetailEditUsecase.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 10/31/23.
+//
+
+import Foundation

--- a/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
+++ b/Manito/Manito/Domain/Usecase/DetailWait/DetailEditUsecase.swift
@@ -10,11 +10,12 @@ import Foundation
 protocol DetailEditUsecase {
     var roomInformation: RoomInfo { get set }
     
+    func validStartDatePast(startDate: String) -> Bool
+    func validMemberCountOver(capacity: Int) -> Bool
     func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int
 }
 
 final class DetailEditUsecaseImpl: DetailEditUsecase {
-    
     @Published var roomInformation: RoomInfo
     
     let repository: DetailRoomRepository
@@ -22,6 +23,17 @@ final class DetailEditUsecaseImpl: DetailEditUsecase {
     init(roomInformation: RoomInfo, repository: DetailRoomRepository) {
         self.roomInformation = roomInformation
         self.repository = repository
+    }
+    
+    func validStartDatePast(startDate: String) -> Bool {
+        guard let startDate = startDate.toDefaultDate else { return false }
+        let isPast = startDate.isPast
+        return !isPast
+    }
+    
+    func validMemberCountOver(capacity: Int) -> Bool {
+        let isUnderOverMember = self.roomInformation.participants.count <= capacity
+        return isUnderOverMember
     }
     
     func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -55,6 +55,7 @@ final class DetailEditViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.updateView(roomInfo: self.roomPublisher.value)
         self.setupPresentationController()
         self.configureDelegation()
         self.bindViewModel()
@@ -72,10 +73,10 @@ final class DetailEditViewController: UIViewController {
         self.detailEditView.configureCalendarDelegate(self)
     }
     
-    private func updateView(roomInfo: RoomInfo) {
-        let startDate = roomInfo.roomInformation.startDate
-        let endDate = roomInfo.roomInformation.endDate
-        let capacity = roomInfo.roomInformation.capacity
+    private func updateView(roomInfo: CreatedRoomInfoRequestDTO) {
+        let startDate = roomInfo.startDate
+        let endDate = roomInfo.endDate
+        let capacity = roomInfo.capacity
         
         self.setupCalendarDateRange(startDate: startDate, endDate: endDate)
         self.setupMemberSliderValue(capacity: capacity)
@@ -118,7 +119,6 @@ final class DetailEditViewController: UIViewController {
     private func transformedOutput() -> DetailEditViewModel.Output? {
         guard let viewModel = self.viewModel as? DetailEditViewModel else { return nil }
         let input = DetailEditViewModel.Input(
-            viewDidLoad: viewDidLoadPublisher,
             changeRoomPublisher: self.roomPublisher.eraseToAnyPublisher(),
             changeButtonDidTap: self.detailEditView.changeButtonPublisher)
         
@@ -127,13 +127,6 @@ final class DetailEditViewController: UIViewController {
     
     private func bindOutputToViewModel(_ output: DetailEditViewModel.Output?) {
         guard let output else { return }
-        
-        output.roomInformation
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] roomInfo in
-                self?.updateView(roomInfo: roomInfo)
-            })
-            .store(in: &self.cancellable)
         
         output.passStartDate
             .receive(on: DispatchQueue.main)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -54,7 +54,7 @@ final class DetailEditViewController: UIViewController {
         self.setupPresentationController()
         self.configureDelegation()
         self.bindViewModel()
-        self.bindCancleButton()
+        self.bindCancelButton()
     }
 
     // MARK: - func
@@ -165,7 +165,7 @@ final class DetailEditViewController: UIViewController {
             .store(in: &self.cancellable)
     }
     
-    private func bindCancleButton() {
+    private func bindCancelButton() {
         self.detailEditView.cancleButtonPublisher
             .sink(receiveValue: { [weak self] _ in
                 self?.dismiss(animated: true)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -147,19 +147,15 @@ final class DetailEditViewController: UIViewController {
         
         output.changeSuccess
             .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { [weak self] result in
+            .sink(receiveValue: { [weak self] result in
                 switch result {
-                case .finished: return
+                case .success(let statusCode):
+                    if statusCode == 204 {
+                        self?.detailWaitDelegate?.didTappedChangeButton()
+                        self?.dismiss(animated: true)
+                    }
                 case .failure(let error):
                     self?.showErrorAlert(error.localizedDescription)
-                }
-            }, receiveValue: { [weak self] statusCode in
-                switch statusCode {
-                case 200..<300:
-                    self?.detailWaitDelegate?.didTappedChangeButton()
-                    self?.dismiss(animated: true)
-                default:
-                    return
                 }
             })
             .store(in: &self.cancellable)

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -21,7 +21,7 @@ final class DetailEditViewController: UIViewController {
     private let editMode: DetailEditView.EditMode
     private let viewModel: any BaseViewModelType
     weak var detailWaitDelegate: DetailWaitViewControllerDelegate?
-    private var cancellable = Set<AnyCancellable>()
+    private var cancellable: Set<AnyCancellable> = Set()
     private var viewModelOutput: DetailEditViewModel.Output?
     
     // MARK: - init

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -28,7 +28,7 @@ final class DetailEditViewController: UIViewController {
     // MARK: - init
     
     init(editMode: DetailEditView.EditMode, room: RoomInfo, viewModel: any BaseViewModelType) {
-        self.detailEditView = DetailEditView(editMode: editMode)
+        self.detailEditView = DetailEditView(editMode: editMode, roomInfo: room)
         self.editMode = editMode
         self.viewModel = viewModel
         self.roomPublisher = .init(CreatedRoomInfoRequestDTO(title: room.roomInformation.title,
@@ -120,7 +120,7 @@ final class DetailEditViewController: UIViewController {
         guard let viewModel = self.viewModel as? DetailEditViewModel else { return nil }
         let input = DetailEditViewModel.Input(
             changeRoomPublisher: self.roomPublisher.eraseToAnyPublisher(),
-            changeButtonDidTap: self.detailEditView.changeButtonPublisher)
+            changeButtonDidTap: self.detailEditView.changeButtonSubject.eraseToAnyPublisher())
         
         return viewModel.transform(from: input)
     }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -130,6 +130,7 @@ final class DetailEditViewController: UIViewController {
         
         output.passStartDate
             .receive(on: DispatchQueue.main)
+            .filter { !$0 }
             .sink(receiveValue: { [weak self] value in
                 self?.showAlertPassedStartDate(value)
             })
@@ -137,6 +138,7 @@ final class DetailEditViewController: UIViewController {
         
         output.overMember
             .receive(on: DispatchQueue.main)
+            .filter { !$0 }
             .sink(receiveValue: { [weak self] value in
                 self?.showAlertOverMember(value)
             })
@@ -209,17 +211,13 @@ final class DetailEditViewController: UIViewController {
 // MARK: - Helper
 extension DetailEditViewController {
     private func showAlertPassedStartDate(_ value: Bool) {
-        if !value {
-            self.makeAlert(title: TextLiteral.Common.Error.title.localized(),
-                            message: TextLiteral.DetailEdit.Error.memberMessage.localized())
-        }
+        self.makeAlert(title: TextLiteral.Common.Error.title.localized(),
+                       message: TextLiteral.DetailEdit.Error.date.localized())
     }
     
     private func showAlertOverMember(_ value: Bool) {
-        if !value {
-            self.makeAlert(title: TextLiteral.DetailEdit.Error.memberTitle.localized(),
-                           message: TextLiteral.DetailEdit.Error.memberMessage.localized())
-        }
+        self.makeAlert(title: TextLiteral.DetailEdit.Error.memberTitle.localized(),
+                       message: TextLiteral.DetailEdit.Error.memberMessage.localized())
     }
     
     private func showErrorAlert(_ text: String) {

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -25,7 +25,9 @@ final class DetailEditViewController: UIViewController {
     
     // MARK: - init
     
-    init(editMode: DetailEditView.EditMode, room: RoomInfo, viewModel: any BaseViewModelType) {
+    init(editMode: DetailEditView.EditMode, 
+         room: RoomInfo,
+         viewModel: any BaseViewModelType) {
         self.detailEditView = DetailEditView(editMode: editMode, roomInfo: room)
         self.editMode = editMode
         self.viewModel = viewModel

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -132,16 +132,16 @@ final class DetailEditViewController: UIViewController {
         output.passStartDate
             .receive(on: DispatchQueue.main)
             .filter { !$0 }
-            .sink(receiveValue: { [weak self] value in
-                self?.showAlertPassedStartDate(value)
+            .sink(receiveValue: { [weak self] _ in
+                self?.showAlertPassedStartDate()
             })
             .store(in: &self.cancellable)
         
         output.overMember
             .receive(on: DispatchQueue.main)
             .filter { !$0 }
-            .sink(receiveValue: { [weak self] value in
-                self?.showAlertOverMember(value)
+            .sink(receiveValue: { [weak self] _ in
+                self?.showAlertOverMember()
             })
             .store(in: &self.cancellable)
         
@@ -177,12 +177,12 @@ final class DetailEditViewController: UIViewController {
 
 // MARK: - Helper
 extension DetailEditViewController {
-    private func showAlertPassedStartDate(_ value: Bool) {
+    private func showAlertPassedStartDate() {
         self.makeAlert(title: TextLiteral.Common.Error.title.localized(),
                        message: TextLiteral.DetailEdit.Error.date.localized())
     }
     
-    private func showAlertOverMember(_ value: Bool) {
+    private func showAlertOverMember() {
         self.makeAlert(title: TextLiteral.DetailEdit.Error.memberTitle.localized(),
                        message: TextLiteral.DetailEdit.Error.memberMessage.localized())
     }

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -160,6 +160,7 @@ final class DetailEditViewController: UIViewController {
             }, receiveValue: { [weak self] statusCode in
                 switch statusCode {
                 case 200..<300:
+                    self?.detailWaitDelegate?.didTappedChangeButton()
                     self?.dismiss(animated: true)
                 default:
                     return

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -68,7 +68,7 @@ final class DetailEditViewController: UIViewController {
         self.detailEditView.configureCalendarDelegate(self)
     }
     
-    private func updateView(roomInfo: RoomInfo) {
+    private func setupRoomInfoView(roomInfo: RoomInfo) {
         let startDate = roomInfo.roomInformation.startDate
         let endDate = roomInfo.roomInformation.endDate
         let capacity = roomInfo.roomInformation.capacity
@@ -125,7 +125,7 @@ final class DetailEditViewController: UIViewController {
         output.roomInfo
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] roomInfo in
-                self?.updateView(roomInfo: roomInfo)
+                self?.setupRoomInfoView(roomInfo: roomInfo)
             })
             .store(in: &self.cancellable)
         

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -129,7 +129,7 @@ final class DetailEditViewController: UIViewController {
             })
             .store(in: &self.cancellable)
         
-        output.passStartDate
+        output.isPassStartDate
             .receive(on: DispatchQueue.main)
             .filter { !$0 }
             .sink(receiveValue: { [weak self] _ in
@@ -137,7 +137,7 @@ final class DetailEditViewController: UIViewController {
             })
             .store(in: &self.cancellable)
         
-        output.overMember
+        output.isOverMember
             .receive(on: DispatchQueue.main)
             .filter { !$0 }
             .sink(receiveValue: { [weak self] _ in

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -22,7 +22,6 @@ final class DetailEditViewController: UIViewController {
     private let viewModel: any BaseViewModelType
     weak var detailWaitDelegate: DetailWaitViewControllerDelegate?
     private var cancellable: Set<AnyCancellable> = Set()
-    private var viewModelOutput: DetailEditViewModel.Output?
     
     // MARK: - init
     
@@ -106,7 +105,6 @@ final class DetailEditViewController: UIViewController {
     
     private func bindViewModel() {
         let output = self.transformedOutput()
-        self.viewModelOutput = output
         self.bindOutputToViewModel(output)
     }
     

--- a/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailEditViewController.swift
@@ -166,7 +166,7 @@ final class DetailEditViewController: UIViewController {
     }
     
     private func bindCancelButton() {
-        self.detailEditView.cancleButtonPublisher
+        self.detailEditView.cancelButtonPublisher
             .sink(receiveValue: { [weak self] _ in
                 self?.dismiss(animated: true)
             })

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -221,7 +221,13 @@ final class DetailWaitViewController: UIViewController, Navigationable {
     }
         
     private func showDetailEditViewController(roomInformation: RoomInfo, mode: DetailEditView.EditMode) {
-        let viewController = DetailEditViewController(editMode: mode, room: roomInformation)
+        let repository = DetailRoomRepositoryImpl()
+        let usecase = DetailEditUsecaseImpl(roomInformation: roomInformation,
+                                            repository: repository)
+        let viewModel = DetailEditViewModel(usecase: usecase)
+        let viewController = DetailEditViewController(editMode: mode,
+                                                      room: roomInformation,
+                                                      viewModel: viewModel)
         viewController.detailWaitDelegate = self
         self.present(viewController, animated: true)
     }

--- a/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
+++ b/Manito/Manito/Screens/Detail-Wait/DetailWaitViewController.swift
@@ -26,7 +26,7 @@ final class DetailWaitViewController: UIViewController, Navigationable {
     private let deleteMenuButtonSubject = PassthroughSubject<Void, Never>()
     private let leaveMenuButtonSubject = PassthroughSubject<Void, Never>()
     private let changeButtonSubject = PassthroughSubject<Void, Never>()
-    private var cancellable = Set<AnyCancellable>()
+    private var cancellable: Set<AnyCancellable> = Set()
     private let detailWaitViewModel: DetailWaitViewModel
     
     // MARK: - init

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -204,11 +204,11 @@ final class CalendarView: UIView {
     }
     
     func getTempStartDate() -> String {
-        return "20\(self.tempStartDateText)"
+        return self.tempStartDateText
     }
     
     func getTempEndDate() -> String {
-        return "20\(self.tempEndDateText)"
+        return self.tempEndDateText
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -202,11 +202,11 @@ final class CalendarView: UIView {
     }
     
     func getTempStartDate() -> String {
-        return self.tempStartDateText
+        return "20\(self.tempStartDateText)"
     }
     
     func getTempEndDate() -> String {
-        return self.tempEndDateText
+        return "20\(self.tempEndDateText)"
     }
 }
 

--- a/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/UIComponent/CalendarView.swift
@@ -154,6 +154,8 @@ final class CalendarView: UIView {
     }
 
     func setupDateRange() {
+        self.startDateTapPublisher.send("20\(self.startDateText)")
+        self.endDateTapPublisher.send("20\(self.endDateText)")
         guard let startDate = self.startDateText.toDefaultDate else { return }
         guard let endDate = self.endDateText.toDefaultDate else { return }
         self.setupCalendarRange(startDate: startDate, endDate: endDate)

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
@@ -280,11 +280,10 @@ final class DetailEditView: UIView, BaseViewType {
     
     private func bindChangeButton() {
         self.changeButton.tapPublisher.sink(receiveValue: { [weak self] _ in
-            self?.changeButtonSubject.send(CreatedRoomInfoRequestDTO(
-                title: self?.roomTitle ?? "",
-                capacity: self?.sliderPublisher.value ?? 0,
-                startDate: "20\(self?.calendarView.getTempStartDate() ?? "")",
-                endDate: "20\(self?.calendarView.getTempEndDate() ?? "")"))
+            self?.changeButtonSubject.send(CreatedRoomInfoRequestDTO(title: self?.roomTitle ?? "",
+                                                                     capacity: self?.sliderPublisher.value ?? 0,
+                                                                     startDate: "20\(self?.calendarView.getTempStartDate() ?? "")",
+                                                                     endDate: "20\(self?.calendarView.getTempEndDate() ?? "")"))
         })
         .store(in: &self.cancellable)
     }

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
@@ -5,14 +5,10 @@
 //  Created by Mingwan Choi on 2023/04/20.
 //
 
+import Combine
 import UIKit
 
 import SnapKit
-
-protocol DetailEditDelegate: AnyObject {
-    func cancelButtonDidTap()
-    func changeButtonDidTap(capacity: Int, from startDate: String, to endDate: String)
-}
 
 final class DetailEditView: UIView, BaseViewType {
     
@@ -104,7 +100,6 @@ final class DetailEditView: UIView, BaseViewType {
     
     // MARK: - property
     
-    private weak var delegate: DetailEditDelegate?
     private weak var calendarDelegate: CalendarDelegate?
     private let editMode: EditMode
     private var maximumMemberCount: Int? {
@@ -113,6 +108,10 @@ final class DetailEditView: UIView, BaseViewType {
                 self.numberOfParticipantsLabel.text = TextLiteral.Common.people.localized(with: count)
             }
         }
+    }
+    
+    var cancleButtonPublisher: AnyPublisher<Void, Never> {
+        return self.cancelButton.tapPublisher
     }
     
     // MARK: - init
@@ -186,8 +185,6 @@ final class DetailEditView: UIView, BaseViewType {
 
     func configureUI() {
         self.backgroundColor = .backgroundGrey
-        self.setupCancleButton()
-        self.setupChangeButton()
     }
 
     // MARK: - func
@@ -226,25 +223,6 @@ final class DetailEditView: UIView, BaseViewType {
         }
     }
     
-    private func setupCancleButton() {
-        let action = UIAction { [weak self] _ in
-            self?.delegate?.cancelButtonDidTap()
-        }
-        self.cancelButton.addAction(action, for: .touchUpInside)
-    }
-    
-    private func setupChangeButton() {
-        let action = UIAction { [weak self] _ in
-            guard let capacity = self?.participantsSlider.value,
-                  let startDateString = self?.calendarView.getTempStartDate(),
-                  let endDateString = self?.calendarView.getTempEndDate() else { return }
-            self?.delegate?.changeButtonDidTap(capacity: Int(capacity),
-                                                  from: startDateString,
-                                                  to: endDateString)
-        }
-        self.changeButton.addAction(action, for: .touchUpInside)
-    }
-    
     func setupChangeButton(_ value: Bool) {
         self.changeButton.isEnabled = value
         self.changeButton.setTitleColor(.subBlue, for: .normal)
@@ -279,10 +257,6 @@ final class DetailEditView: UIView, BaseViewType {
             self.calendarView.endDateText = endDateString
         }
         self.calendarView.setupDateRange()
-    }
-    
-    func configureDelegation(_ delegate: DetailEditDelegate) {
-        self.delegate = delegate
     }
     
     func configureCalendarDelegate(_ delegate: CalendarDelegate) {

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
@@ -114,7 +114,7 @@ final class DetailEditView: UIView, BaseViewType {
     private let capacity: Int
     private var cancellable = Set<AnyCancellable>()
     
-    var cancleButtonPublisher: AnyPublisher<Void, Never> {
+    var cancelButtonPublisher: AnyPublisher<Void, Never> {
         return self.cancelButton.tapPublisher
     }
     

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
@@ -114,6 +114,14 @@ final class DetailEditView: UIView, BaseViewType {
         return self.cancelButton.tapPublisher
     }
     
+    var changeButtonPublisher: AnyPublisher<Void, Never> {
+        return self.changeButton.tapPublisher
+    }
+    
+    var sliderPublisher: AnyPublisher<Float, Never> {
+        return self.participantsSlider.valuePublisher
+    }
+    
     // MARK: - init
     
     init(editMode: EditMode) {

--- a/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
+++ b/Manito/Manito/Screens/Detail-Wait/View/DetailEditView.swift
@@ -280,10 +280,11 @@ final class DetailEditView: UIView, BaseViewType {
     
     private func bindChangeButton() {
         self.changeButton.tapPublisher.sink(receiveValue: { [weak self] _ in
-            self?.changeButtonSubject.send(CreatedRoomInfoRequestDTO(title: self?.roomTitle ?? "",
-                                                                     capacity: self?.sliderPublisher.value ?? 0,
-                                                                     startDate: self?.calendarView.getTempStartDate() ?? "",
-                                                                     endDate: self?.calendarView.getTempEndDate() ?? ""))
+            self?.changeButtonSubject.send(CreatedRoomInfoRequestDTO(
+                title: self?.roomTitle ?? "",
+                capacity: self?.sliderPublisher.value ?? 0,
+                startDate: "20\(self?.calendarView.getTempStartDate() ?? "")",
+                endDate: "20\(self?.calendarView.getTempEndDate() ?? "")"))
         })
         .store(in: &self.cancellable)
     }

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -24,7 +24,6 @@ final class DetailEditViewModel: BaseViewModelType {
     private var cancellable: Set<AnyCancellable> = Set()
     
     init(usecase: DetailEditUsecase) {
-        let roomInfo = usecase.roomInformation.roomInformation
         self.usecase = usecase
     }
     

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -15,8 +15,8 @@ final class DetailEditViewModel: BaseViewModelType {
     }
     struct Output {
         let roomInfo: AnyPublisher<RoomInfo, Never>
-        let passStartDate: AnyPublisher<Bool, Never>
-        let overMember: AnyPublisher<Bool, Never>
+        let isPassStartDate: AnyPublisher<Bool, Never>
+        let isOverMember: AnyPublisher<Bool, Never>
         let changeSuccess: AnyPublisher<Int, Error>
     }
     
@@ -64,8 +64,8 @@ final class DetailEditViewModel: BaseViewModelType {
         
         return Output(
             roomInfo: roomInfoOutput,
-            passStartDate: isPastPublisher,
-            overMember: isMemberOverPublisher,
+            isPassStartDate: isPastPublisher,
+            isOverMember: isMemberOverPublisher,
             changeSuccess: changeRoomOutput)
     }
 }

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -20,8 +20,8 @@ final class DetailEditViewModel: BaseViewModelType {
         let changeSuccess: AnyPublisher<Result<Int, Error>, Never>
     }
     
-    let usecase: DetailEditUsecase
-    private var cancellable = Set<AnyCancellable>()
+    private let usecase: DetailEditUsecase
+    private var cancellable: Set<AnyCancellable> = Set()
     
     init(usecase: DetailEditUsecase) {
         let roomInfo = usecase.roomInformation.roomInformation

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -25,10 +25,6 @@ final class DetailEditViewModel: BaseViewModelType {
     
     init(usecase: DetailEditUsecase) {
         let roomInfo = usecase.roomInformation.roomInformation
-        let dto = CreatedRoomInfoRequestDTO(title: roomInfo.title,
-                                            capacity: roomInfo.capacity,
-                                            startDate: roomInfo.startDate,
-                                            endDate: roomInfo.endDate)
         self.usecase = usecase
     }
     

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -38,23 +38,23 @@ final class DetailEditViewModel: BaseViewModelType {
         
         let isPastPublisher = input.changeButtonDidTap
             .compactMap { [weak self] dto in
-                self?.usecase.validStartDatePast(startDate: dto.startDate)
+                self?.usecase.vaildStartDateIsNotPast(startDate: dto.startDate)
             }
             .eraseToAnyPublisher()
         
         let isMemberOverPublisher = input.changeButtonDidTap
             .compactMap { [weak self] dto in
-                self?.usecase.validMemberCountOver(capacity: dto.capacity)
+                self?.usecase.vaildMemberCountIsUnder(capacity: dto.capacity)
             }
             .eraseToAnyPublisher()
         
         let changeRoomOutput = input.changeButtonDidTap
             .filter { [weak self] dto in
                 guard let self else { return false }
-                return self.usecase.validMemberCountOver(capacity: dto.capacity) }
+                return self.usecase.vaildMemberCountIsUnder(capacity: dto.capacity) }
             .filter { [weak self] dto in
                 guard let self else { return false }
-                return self.usecase.validStartDatePast(startDate: dto.startDate) }
+                return self.usecase.vaildStartDateIsNotPast(startDate: dto.startDate) }
             .asyncMap { [weak self] dto -> Result<Int, Error> in
                 do {
                     let statusCode = try await self?.usecase.changeRoomInformation(roomDto: dto)

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -10,12 +10,10 @@ import Foundation
 
 final class DetailEditViewModel: BaseViewModelType {
     struct Input {
-        let viewDidLoad: AnyPublisher<Void, Never>
         let changeRoomPublisher: AnyPublisher<CreatedRoomInfoRequestDTO, Never>
         let changeButtonDidTap: AnyPublisher<Void, Never>
     }
     struct Output {
-        let roomInformation: AnyPublisher<RoomInfo, Never>
         let passStartDate: AnyPublisher<Bool, Never>
         let overMember: AnyPublisher<Bool, Never>
         let changeSuccess: AnyPublisher<Int, Error>
@@ -30,12 +28,6 @@ final class DetailEditViewModel: BaseViewModelType {
     // MARK: - func
     
     func transform(from input: Input) -> Output {
-        let roomInformationOutput = input.viewDidLoad
-            .compactMap { [weak self] _ in
-                return self?.usecase.roomInformation
-            }
-            .eraseToAnyPublisher()
-        
         let isPastPublisher = input.changeButtonDidTap.combineLatest(input.changeRoomPublisher)
             .compactMap { [weak self] _, dto in
                 self?.validStartDatePast(startDate: dto.startDate)
@@ -54,13 +46,10 @@ final class DetailEditViewModel: BaseViewModelType {
             }
             .compactMap { $0 }
             .eraseToAnyPublisher()
-            
         
-        return Output(roomInformation: roomInformationOutput,
-                      passStartDate: isPastPublisher,
+        return Output(passStartDate: isPastPublisher,
                       overMember: isMemberOverPublisher,
-                      changeSuccess: changeRoomOutput
-        )
+                      changeSuccess: changeRoomOutput)
     }
     
     private func validStartDatePast(startDate: String) -> Bool {

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  DetailEditViewModel.swift
+//  Manito
+//
+//  Created by Mingwan Choi on 10/31/23.
+//
+
+import Foundation

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -43,25 +43,25 @@ final class DetailEditViewModel: BaseViewModelType {
         
         let isPastPublisher = input.changeButtonDidTap
             .compactMap { [weak self] dto in
-                self?.validStartDatePast(startDate: dto.startDate)
+                self?.usecase.validStartDatePast(startDate: dto.startDate)
             }
             .eraseToAnyPublisher()
         
         let isMemberOverPublisher = input.changeButtonDidTap
             .compactMap { [weak self] dto in
-                self?.validMemberCountOver(capacity: dto.capacity)
+                self?.usecase.validMemberCountOver(capacity: dto.capacity)
             }
             .eraseToAnyPublisher()
         
         let changeRoomOutput = input.changeButtonDidTap
             .filter { [weak self] dto in
                 guard let self else { return false }
-                return self.validMemberCountOver(capacity: dto.capacity) }
+                return self.usecase.validMemberCountOver(capacity: dto.capacity) }
             .filter { [weak self] dto in
                 guard let self else { return false }
-                return self.validStartDatePast(startDate: dto.startDate) }
+                return self.usecase.validStartDatePast(startDate: dto.startDate) }
             .asyncMap { [weak self] dto in
-                try await self?.changeRoomInformation(roomDto: dto)
+                try await self?.usecase.changeRoomInformation(roomDto: dto)
             }
             .compactMap { $0 }
             .eraseToAnyPublisher()
@@ -71,21 +71,5 @@ final class DetailEditViewModel: BaseViewModelType {
             passStartDate: isPastPublisher,
             overMember: isMemberOverPublisher,
             changeSuccess: changeRoomOutput)
-    }
-    
-    private func validStartDatePast(startDate: String) -> Bool {
-        guard let startDate = startDate.toDefaultDate else { return false }
-        let isPast = startDate.isPast
-        return !isPast
-    }
-    
-    private func validMemberCountOver(capacity: Int) -> Bool {
-        let isUnderOverMember = self.usecase.roomInformation.participants.count <= capacity
-        return isUnderOverMember
-    }
-    
-    private func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {
-        let statusCode = try await self.usecase.changeRoomInformation(roomDto: roomDto)
-        return statusCode
     }
 }

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailEditViewModel.swift
@@ -5,4 +5,77 @@
 //  Created by Mingwan Choi on 10/31/23.
 //
 
+import Combine
 import Foundation
+
+final class DetailEditViewModel: BaseViewModelType {
+    struct Input {
+        let viewDidLoad: AnyPublisher<Void, Never>
+        let changeRoomPublisher: AnyPublisher<CreatedRoomInfoRequestDTO, Never>
+        let changeButtonDidTap: AnyPublisher<Void, Never>
+    }
+    struct Output {
+        let roomInformation: AnyPublisher<RoomInfo, Never>
+        let passStartDate: AnyPublisher<Bool, Never>
+        let overMember: AnyPublisher<Bool, Never>
+        let changeSuccess: AnyPublisher<Int, Error>
+    }
+    
+    let usecase: DetailEditUsecase
+    
+    init(usecase: DetailEditUsecase) {
+        self.usecase = usecase
+    }
+    
+    // MARK: - func
+    
+    func transform(from input: Input) -> Output {
+        let roomInformationOutput = input.viewDidLoad
+            .compactMap { [weak self] _ in
+                return self?.usecase.roomInformation
+            }
+            .eraseToAnyPublisher()
+        
+        let isPastPublisher = input.changeButtonDidTap.combineLatest(input.changeRoomPublisher)
+            .compactMap { [weak self] _, dto in
+                self?.validStartDatePast(startDate: dto.startDate)
+            }
+            .eraseToAnyPublisher()
+        
+        let isMemberOverPublisher = input.changeButtonDidTap.combineLatest(input.changeRoomPublisher)
+            .compactMap { [weak self] _, dto in
+                self?.validMemberCountOver(capacity: dto.capacity)
+            }
+            .eraseToAnyPublisher()
+        
+        let changeRoomOutput = input.changeButtonDidTap.combineLatest(input.changeRoomPublisher)
+            .asyncMap { [weak self] _, dto in
+                try await self?.changeRoomInformation(roomDto: dto)
+            }
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+            
+        
+        return Output(roomInformation: roomInformationOutput,
+                      passStartDate: isPastPublisher,
+                      overMember: isMemberOverPublisher,
+                      changeSuccess: changeRoomOutput
+        )
+    }
+    
+    private func validStartDatePast(startDate: String) -> Bool {
+        guard let startDate = startDate.toDefaultDate else { return false }
+        let isPast = startDate.isPast
+        return !isPast
+    }
+    
+    private func validMemberCountOver(capacity: Int) -> Bool {
+        let isOverMember = self.usecase.roomInformation.participants.count > capacity
+        return !isOverMember
+    }
+    
+    private func changeRoomInformation(roomDto: CreatedRoomInfoRequestDTO) async throws -> Int {
+        let statusCode = try await self.usecase.changeRoomInformation(roomDto: roomDto)
+        return statusCode
+    }
+}

--- a/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailWaitViewModel.swift
+++ b/Manito/Manito/Screens/Detail-Wait/ViewModel/DetailWaitViewModel.swift
@@ -57,7 +57,7 @@ final class DetailWaitViewModel {
     // MARK: - property
     
     let roomId: String
-    private var cancellable = Set<AnyCancellable>()
+    private var cancellable: Set<AnyCancellable> = Set()
     private let usecase: DetailWaitUseCase
     
     // MARK: - init

--- a/Manito/Manito/Util/Extension/Combine/UIControl+Combine.swift
+++ b/Manito/Manito/Util/Extension/Combine/UIControl+Combine.swift
@@ -74,3 +74,12 @@ extension UISegmentedControl {
             .eraseToAnyPublisher()
     }
 }
+
+extension UISlider {
+    var valuePublisher: AnyPublisher<Float, Never> {
+        controlPublisher(for: .valueChanged)
+            .map { $0 as! UISlider }
+            .map { $0.value }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Manito/Manito/Util/Extension/Combine/UIControl+Combine.swift
+++ b/Manito/Manito/Util/Extension/Combine/UIControl+Combine.swift
@@ -74,12 +74,3 @@ extension UISegmentedControl {
             .eraseToAnyPublisher()
     }
 }
-
-extension UISlider {
-    var valuePublisher: AnyPublisher<Float, Never> {
-        controlPublisher(for: .valueChanged)
-            .map { $0 as! UISlider }
-            .map { $0.value }
-            .eraseToAnyPublisher()
-    }
-}

--- a/Manito/Manito/Util/Literal/TextLiteral.swift
+++ b/Manito/Manito/Util/Literal/TextLiteral.swift
@@ -133,6 +133,7 @@ enum TextLiteral {
             static let message = "detail_edit_error_message"
             static let memberTitle = "detail_edit_member_error_title"
             static let memberMessage = "detail_edit_member_error_message"
+            static let date = "detail_edit_date_error_message"
         }
     }
 

--- a/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
+++ b/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
@@ -19,7 +19,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         self.mockUsecase = nil
     }
     
-    func test_validStartDatePast함수에_올바른_날짜형식의_텍스트에_반응하는가() {
+    func test_vaildStartDateIsNotPast함수에_올바른_날짜형식의_텍스트에_반응하는가() {
         // given
         let date = "aaaa.aa.aa"
         // when
@@ -28,7 +28,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertFalse(sut)
     }
     
-    func test_validStartDatePast함수에_과거날짜가_들어갔을때() {
+    func test_vaildStartDateIsNotPast함수에_과거날짜가_들어갔을때() {
         // given
         let date = "2000.01.01"
         // when
@@ -37,7 +37,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertFalse(sut)
     }
     
-    func test_validStartDatePast함수에_오늘날짜가_들어갔을때() {
+    func test_vaildStartDateIsNotPast함수에_오늘날짜가_들어갔을때() {
         // given
         let today = Date().toFullString
         // when
@@ -46,7 +46,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertTrue(sut)
     }
     
-    func test_validStartDatePast함수에_내일날짜가_들어갔을때() {
+    func test_vaildStartDateIsNotPast함수에_내일날짜가_들어갔을때() {
         // given
         let oneDay: TimeInterval = 86400
         let tomorrow = (Date() + oneDay).toFullString
@@ -56,7 +56,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertTrue(sut)
     }
     
-    func test_validStartDatePast함수에_먼미래날짜가_들어갔을때() {
+    func test_vaildStartDateIsNotPast함수에_먼미래날짜가_들어갔을때() {
         // given
         let date = "2050.01.01"
         // when
@@ -65,7 +65,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertTrue(sut)
     }
     
-    func test_validMemberCountOver함수에_5명이참여중인데_4명으로_수정했을때() {
+    func test_vaildMemberCountIsUnder함수에_5명이참여중인데_4명으로_수정했을때() {
         // given
         let capacity = 4
         // when
@@ -74,7 +74,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertFalse(sut)
     }
     
-    func test_validMemberCountOver함수에_5명이참여중인데_5명으로_수정했을때() {
+    func test_vaildMemberCountIsUnder함수에_5명이참여중인데_5명으로_수정했을때() {
         // given
         let capacity = 5
         // when
@@ -83,7 +83,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         XCTAssertTrue(sut)
     }
     
-    func test_validMemberCountOver함수에_5명이참여중인데_10명으로_수정했을때() {
+    func test_vaildMemberCountIsUnder함수에_5명이참여중인데_10명으로_수정했을때() {
         // given
         let capacity = 10
         // when

--- a/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
+++ b/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
@@ -23,7 +23,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let date = "aaaa.aa.aa"
         // when
-        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        let sut = self.mockUsecase.vaildStartDateIsNotPast(startDate: date)
         // then
         XCTAssertFalse(sut)
     }
@@ -32,7 +32,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let date = "2000.01.01"
         // when
-        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        let sut = self.mockUsecase.vaildStartDateIsNotPast(startDate: date)
         // then
         XCTAssertFalse(sut)
     }
@@ -41,7 +41,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let today = Date().toFullString
         // when
-        let sut = self.mockUsecase.validStartDatePast(startDate: today)
+        let sut = self.mockUsecase.vaildStartDateIsNotPast(startDate: today)
         // then
         XCTAssertTrue(sut)
     }
@@ -51,7 +51,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         let oneDay: TimeInterval = 86400
         let tomorrow = (Date() + oneDay).toFullString
         // when
-        let sut = self.mockUsecase.validStartDatePast(startDate: tomorrow)
+        let sut = self.mockUsecase.vaildStartDateIsNotPast(startDate: tomorrow)
         // then
         XCTAssertTrue(sut)
     }
@@ -60,7 +60,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let date = "2050.01.01"
         // when
-        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        let sut = self.mockUsecase.vaildStartDateIsNotPast(startDate: date)
         // then
         XCTAssertTrue(sut)
     }
@@ -69,7 +69,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let capacity = 4
         // when
-        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        let sut = self.mockUsecase.vaildMemberCountIsUnder(capacity: capacity)
         // then
         XCTAssertFalse(sut)
     }
@@ -78,7 +78,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let capacity = 5
         // when
-        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        let sut = self.mockUsecase.vaildMemberCountIsUnder(capacity: capacity)
         // then
         XCTAssertTrue(sut)
     }
@@ -87,7 +87,7 @@ final class DetailEditUsecaseTest: XCTestCase {
         // given
         let capacity = 10
         // when
-        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        let sut = self.mockUsecase.vaildMemberCountIsUnder(capacity: capacity)
         // then
         XCTAssertTrue(sut)
     }
@@ -120,13 +120,13 @@ final class MockDetailEditUsecase: DetailEditUsecase {
         self.roomInformation = roomInformation
     }
     
-    func validStartDatePast(startDate: String) -> Bool {
-        let value = self.usecaseImpl.validStartDatePast(startDate: startDate)
+    func vaildStartDateIsNotPast(startDate: String) -> Bool {
+        let value = self.usecaseImpl.vaildStartDateIsNotPast(startDate: startDate)
         return value
     }
     
-    func validMemberCountOver(capacity: Int) -> Bool {
-        let value = self.usecaseImpl.validMemberCountOver(capacity: capacity)
+    func vaildMemberCountIsUnder(capacity: Int) -> Bool {
+        let value = self.usecaseImpl.vaildMemberCountIsUnder(capacity: capacity)
         return value
     }
     

--- a/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
+++ b/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
@@ -1,0 +1,35 @@
+//
+//  DetailEditUsecaseTest.swift
+//  ManitoTests
+//
+//  Created by Mingwan Choi on 11/8/23.
+//
+
+import XCTest
+
+final class DetailEditUsecaseTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
+++ b/Manito/ManitoTests/Domain/Usecase/DetailEditUsecaseTest.swift
@@ -6,30 +6,133 @@
 //
 
 import XCTest
+@testable import Manito
 
 final class DetailEditUsecaseTest: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    private var mockUsecase: DetailEditUsecase!
+    
+    override func setUp() {
+        self.mockUsecase = MockDetailEditUsecase(roomInformation: .testRoom)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    
+    override func tearDown() {
+        self.mockUsecase = nil
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    
+    func test_validStartDatePast함수에_올바른_날짜형식의_텍스트에_반응하는가() {
+        // given
+        let date = "aaaa.aa.aa"
+        // when
+        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        // then
+        XCTAssertFalse(sut)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    
+    func test_validStartDatePast함수에_과거날짜가_들어갔을때() {
+        // given
+        let date = "2000.01.01"
+        // when
+        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        // then
+        XCTAssertFalse(sut)
+    }
+    
+    func test_validStartDatePast함수에_오늘날짜가_들어갔을때() {
+        // given
+        let today = Date().toFullString
+        // when
+        let sut = self.mockUsecase.validStartDatePast(startDate: today)
+        // then
+        XCTAssertTrue(sut)
+    }
+    
+    func test_validStartDatePast함수에_내일날짜가_들어갔을때() {
+        // given
+        let oneDay: TimeInterval = 86400
+        let tomorrow = (Date() + oneDay).toFullString
+        // when
+        let sut = self.mockUsecase.validStartDatePast(startDate: tomorrow)
+        // then
+        XCTAssertTrue(sut)
+    }
+    
+    func test_validStartDatePast함수에_먼미래날짜가_들어갔을때() {
+        // given
+        let date = "2050.01.01"
+        // when
+        let sut = self.mockUsecase.validStartDatePast(startDate: date)
+        // then
+        XCTAssertTrue(sut)
+    }
+    
+    func test_validMemberCountOver함수에_5명이참여중인데_4명으로_수정했을때() {
+        // given
+        let capacity = 4
+        // when
+        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        // then
+        XCTAssertFalse(sut)
+    }
+    
+    func test_validMemberCountOver함수에_5명이참여중인데_5명으로_수정했을때() {
+        // given
+        let capacity = 5
+        // when
+        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        // then
+        XCTAssertTrue(sut)
+    }
+    
+    func test_validMemberCountOver함수에_5명이참여중인데_10명으로_수정했을때() {
+        // given
+        let capacity = 10
+        // when
+        let sut = self.mockUsecase.validMemberCountOver(capacity: capacity)
+        // then
+        XCTAssertTrue(sut)
+    }
+    
+    func test_changeRoomInformation() async throws {
+        let dto: CreatedRoomInfoRequestDTO = .init(title: "테스트",
+                                                   capacity: 5,
+                                                   startDate: "2025.01.01",
+                                                   endDate: "2025.01.05")
+        
+        do {
+            let statusCode = try await self.mockUsecase.changeRoomInformation(roomDto: dto)
+            if statusCode == 204 {
+                XCTAssertTrue(true)
+            } else {
+                XCTFail()
+            }
+        } catch {
+            XCTFail()
         }
     }
+}
 
+final class MockDetailEditUsecase: DetailEditUsecase {
+    private let usecaseImpl: DetailEditUsecase = DetailEditUsecaseImpl(roomInformation: .testRoom,
+                                                                       repository: DetailRoomRepositoryImpl())
+    var roomInformation: Manito.RoomInfo
+    
+    init(roomInformation: Manito.RoomInfo) {
+        self.roomInformation = roomInformation
+    }
+    
+    func validStartDatePast(startDate: String) -> Bool {
+        let value = self.usecaseImpl.validStartDatePast(startDate: startDate)
+        return value
+    }
+    
+    func validMemberCountOver(capacity: Int) -> Bool {
+        let value = self.usecaseImpl.validMemberCountOver(capacity: capacity)
+        return value
+    }
+    
+    func changeRoomInformation(roomDto: Manito.CreatedRoomInfoRequestDTO) async throws -> Int {
+        try await Task.sleep(nanoseconds: 3_000)
+        
+        return 204
+    }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
대기방 View에 이어 방 정보 수정 View를 이어서 리팩토링 했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 대기방 View 리팩토링
2. UISlider에 대한 Publisher 추가
3. 캘린더 View의 날짜 Subject 값 전달

- 날짜를 선택하고 변경 버튼을 눌렀을때, 시작 날짜가 오늘보다 과거이면 Alert이 뜨게끔 만들었습니다. (이미 캘린더 View에서 UI적으로 막고있음)
- 최대 인원이 현재 참여한 인원보다 많을때, Alert이 뜨게끔 만들었습니다.

ViewModel에서 Input에 방 정보가 이미 오는데도 `var roomDto: CurrentValueSubject<CreatedRoomInfoRequestDTO, Never>` 변수를 사용한 이유가 따로 있습니다. 아래 리뷰 노트에 살짝 적긴 했는데, 노션에 11월 7일 iOS 회의록에 개발중 느꼈던 문제에 대해 적었습니다 참고해주셔요 🙇‍♂️

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`feature/586-detailedit-mvvm` 브랜치로 오셔서 테스트를 해볼 순 있지만, 방에 사람이 5명이상 들어와있어야 하기 때문에 불편하실까봐 아래 영상으로 첨부했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<!--  <img src="사진 크기를 줄이고 싶다면 여기 넣어주세요 !.png" width="350">   -->

https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/e32d8182-9e7d-48f5-b21a-aef6f83d72f2






## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이번 리팩토링을 하면서 많이 막혀서 시간이 꽤 걸렸네요... 여러분들께 도움을 요청하려고 노션에 상황을 정리하고 있었는데 적다보니 어? 이렇게 하면 될 것 같은데..? 싶어서 해보니 되길래 무사히 완료했습니다..ㅎㅎ
역시 모르는걸 질문할때 문제가 해결되는 법이죠 👍

### 노션을 일부 캡쳐한 사진입니다.
<img width="670" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC2-Team5-Firefighter/assets/78677571/b707cf22-e2e8-48c1-a777-0b0bb67726cb">




Usecase나 ViewModel에서 구조를 더 예쁘게 수정할 수 있는 방법이 있다면 알려주시면 감사하겠습니다.

추후엔 캘린더를 리팩토링해야겠네요.. 코드가 너무 못생겼어요ㅠㅠ
1년 전의 저에 비해 많이 성장한 것 같네요

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #586


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- https://velog.io/@aurora_97/Combine-UIKit%EC%97%90%EC%84%9C-Combine-%ED%8E%B8%ED%95%98%EA%B2%8C-%EC%93%B0%EA%B8%B0